### PR TITLE
Limits: Log-tail probe for Codex usage (no PTY/REPL)

### DIFF
--- a/AgentSessions.xcodeproj/project.pbxproj
+++ b/AgentSessions.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		DAC510E5A5804B0C865935FC /* CodexResumeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DF05EC4F8049DA9AF9E5CD /* CodexResumeCoordinator.swift */; };
 		580BD9BD812D40E0A54F28D2 /* CodexResumeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C60C047C8842A9B8A7AA2A /* CodexResumeCoordinatorTests.swift */; };
 		D1E2F3A4B5C647E8F9A0B1C2 /* ResumeHealthCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C4C1F0A1B24C7DA0D1E2F3 /* ResumeHealthCheck.swift */; };
+        C0D3E5A1700A000000000001 /* CodexStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3E5A1700F000000000001 /* CodexStatusService.swift */; };
+        C0D3E5A1700A000000000002 /* UsageStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3E5A1700F000000000002 /* UsageStripView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,6 +102,8 @@
         7E8EFD200FFA4B90BCCF3434 /* CodexResumeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodexResumeSheet.swift; path = AgentSessions/Resume/CodexResumeSheet.swift; sourceTree = SOURCE_ROOT; };
         46DF05EC4F8049DA9AF9E5CD /* CodexResumeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodexResumeCoordinator.swift; path = AgentSessions/Resume/CodexResumeCoordinator.swift; sourceTree = SOURCE_ROOT; };
         C9C4C1F0A1B24C7DA0D1E2F3 /* ResumeHealthCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ResumeHealthCheck.swift; path = AgentSessions/Resume/ResumeHealthCheck.swift; sourceTree = SOURCE_ROOT; };
+        C0D3E5A1700F000000000001 /* CodexStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodexStatusService.swift; path = AgentSessions/CodexStatus/CodexStatusService.swift; sourceTree = SOURCE_ROOT; };
+        C0D3E5A1700F000000000002 /* UsageStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UsageStripView.swift; path = AgentSessions/CodexStatus/UsageStripView.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,10 +136,20 @@
                 B0000012CA0A000100000001 /* Utilities */,
                 B0000012DA0A000100000001 /* Views */,
                 193183E356AF4718A7B9CB7F /* Resume */,
+                C0D3E5A1700C000000000001 /* CodexStatus */,
                 B00000112A0A000100000001 /* AgentSessionsApp.swift */
             );
             path = AgentSessions;
             sourceTree = SOURCE_ROOT;
+        };
+        C0D3E5A1700C000000000001 /* CodexStatus */ = {
+            isa = PBXGroup;
+            children = (
+                C0D3E5A1700F000000000001 /* CodexStatusService.swift */,
+                C0D3E5A1700F000000000002 /* UsageStripView.swift */
+            );
+            path = CodexStatus;
+            sourceTree = "<group>";
         };
         B00000127A0A000100000001 /* AgentSessionsTests */ = {isa = PBXGroup; children = (B00000120A0A000100000001 /* Info.plist */, B0000011FA0A000100000001 /* SessionParserTests.swift */, B00000173A0A000100000001 /* TranscriptBuilderTests.swift */, B00000179A0A000100000001 /* SessionTitleTests.swift */, A85CE64F2E8C4DCFAFF1B93C /* CodexResumeTests.swift */, F6C60C047C8842A9B8A7AA2A /* CodexResumeCoordinatorTests.swift */); path = AgentSessionsTests; sourceTree = SOURCE_ROOT; };
         B00000128A0A000100000001 /* Resources */ = {isa = PBXGroup; children = (B0000012EA0A000100000001 /* Fixtures */); path = Resources; sourceTree = SOURCE_ROOT; };
@@ -144,7 +158,6 @@
         B0000012AA0A000100000001 /* Model */ = {isa = PBXGroup; children = (B00000113A0A000100000001 /* Session.swift */, B00000114A0A000100000001 /* SessionEvent.swift */); path = Model; sourceTree = "<group>"; };
         B0000012BA0A000100000001 /* Services */ = {isa = PBXGroup; children = (B00000115A0A000100000001 /* SessionIndexer.swift */, B00000170A0A000100000001 /* TranscriptTheme.swift */, B00000171A0A000100000001 /* SessionTranscriptBuilder.swift */, B00000178A0A000100000001 /* AppAppearance.swift */, B0000017BA0A000100000001 /* LayoutMode.swift */); path = Services; sourceTree = "<group>"; };
         B0000012CA0A000100000001 /* Utilities */ = {isa = PBXGroup; children = (B0000011BA0A000100000001 /* JSONLReader.swift */, B0000011CA0A000100000001 /* PrettyJSON.swift */, B00000176A0A000100000001 /* PreferencesWindowController.swift */, B00000177A0A000100000001 /* FlowLayout.swift */); path = Utilities; sourceTree = "<group>"; };
-		// Insert new file into Utilities group
         B0000012DA0A000100000001 /* Views */ = {isa = PBXGroup; children = (B00000116A0A000100000001 /* SessionsListView.swift */, B00000175A0A000100000001 /* TranscriptPlainView.swift */, B00000117A0A000100000001 /* SessionTimelineView.swift */, B00000118A0A000100000001 /* EventInspectorView.swift */, B00000119A0A000100000001 /* SearchFiltersView.swift */, B0000011AA0A000100000001 /* PreferencesView.swift */); path = Views; sourceTree = "<group>"; };
         193183E356AF4718A7B9CB7F /* Resume */ = {
             isa = PBXGroup;
@@ -257,7 +270,9 @@
                 A8B49E614242407C854A3463 /* CodexResumeLauncher.swift in Sources */,
                 2B31E3D104D74827B0E65D5E /* CodexResumeSheet.swift in Sources */,
                 D1E2F3A4B5C647E8F9A0B1C2 /* ResumeHealthCheck.swift in Sources */,
-                DAC510E5A5804B0C865935FC /* CodexResumeCoordinator.swift in Sources */
+                DAC510E5A5804B0C865935FC /* CodexResumeCoordinator.swift in Sources */,
+                C0D3E5A1700A000000000001 /* CodexStatusService.swift in Sources */,
+                C0D3E5A1700A000000000002 /* UsageStripView.swift in Sources */
             ); runOnlyForDeploymentPostprocessing = 0; };
         B00000132A0A000100000001 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (B000001C2A0A00010000000D /* SessionParserTests.swift in Sources */, B000001C2A0A000100000074 /* TranscriptBuilderTests.swift in Sources */, B000001C2A0A000100000078 /* SessionTitleTests.swift in Sources */, F7079DCFE7E6447F920DBF84 /* CodexResumeTests.swift in Sources */, 580BD9BD812D40E0A54F28D2 /* CodexResumeCoordinatorTests.swift in Sources */); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXSourcesBuildPhase section */

--- a/AgentSessions/CodexStatus/CodexStatusService.swift
+++ b/AgentSessions/CodexStatus/CodexStatusService.swift
@@ -1,0 +1,576 @@
+import Foundation
+import SwiftUI
+
+// ILLUSTRATIVE: Minimal model + service for Codex /status usage parsing.
+
+// Snapshot of parsed values from Codex /status or banner
+struct CodexUsageSnapshot: Equatable {
+    var fiveHourPercent: Int = 0
+    var fiveHourResetText: String = ""
+    var weekPercent: Int = 0
+    var weekResetText: String = ""
+    var usageLine: String? = nil
+    var accountLine: String? = nil
+    var modelLine: String? = nil
+}
+
+@MainActor
+final class CodexUsageModel: ObservableObject {
+    static let shared = CodexUsageModel()
+
+    @Published var fiveHourPercent: Int = 0
+    @Published var fiveHourResetText: String = ""
+    @Published var weekPercent: Int = 0
+    @Published var weekResetText: String = ""
+    @Published var usageLine: String? = nil
+    @Published var accountLine: String? = nil
+    @Published var modelLine: String? = nil
+    @Published var lastUpdate: Date? = nil
+    @Published var cliUnavailable: Bool = false
+
+    private var service: CodexStatusService?
+    private var isEnabled: Bool = false
+
+    func setEnabled(_ enabled: Bool) {
+        guard enabled != isEnabled else { return }
+        isEnabled = enabled
+        if enabled {
+            start()
+        } else {
+            stop()
+        }
+    }
+
+    func setVisible(_ visible: Bool) {
+        Task.detached { [weak self] in
+            await self?.service?.setVisible(visible)
+        }
+    }
+
+    func refreshNow() {
+        Task.detached { [weak self] in
+            await self?.service?.refreshNow()
+        }
+    }
+
+    private func start() {
+        let model = self
+        let handler: @Sendable (CodexUsageSnapshot) -> Void = { snapshot in
+            Task { @MainActor in
+                model.apply(snapshot)
+            }
+        }
+        let availabilityHandler: @Sendable (Bool) -> Void = { unavailable in
+            Task { @MainActor in
+                model.cliUnavailable = unavailable
+            }
+        }
+        let service = CodexStatusService(updateHandler: handler, availabilityHandler: availabilityHandler)
+        self.service = service
+        Task.detached {
+            await service.start()
+        }
+    }
+
+    private func stop() {
+        Task.detached { [service] in
+            await service?.stop()
+        }
+        service = nil
+    }
+
+    private func apply(_ s: CodexUsageSnapshot) {
+        fiveHourPercent = clampPercent(s.fiveHourPercent)
+        weekPercent = clampPercent(s.weekPercent)
+        fiveHourResetText = s.fiveHourResetText
+        weekResetText = s.weekResetText
+        usageLine = s.usageLine
+        accountLine = s.accountLine
+        modelLine = s.modelLine
+        lastUpdate = Date()
+    }
+
+    private func clampPercent(_ v: Int) -> Int { max(0, min(100, v)) }
+}
+
+// MARK: - Rate-limit models (log probe)
+
+struct RateLimitWindow {
+    var usedPercent: Int?
+    var resetAt: Date?
+    var windowMinutes: Int?
+}
+
+struct RateLimitSummary {
+    var fiveHour: RateLimitWindow
+    var weekly: RateLimitWindow
+    var eventTimestamp: Date?
+    var stale: Bool
+    var sourceFile: URL?
+}
+
+// MARK: - Service
+
+actor CodexStatusService {
+    private enum State { case idle, starting, running, stopping }
+
+    // Regex helpers
+    private let percentRegex = try! NSRegularExpression(pattern: "(\\d{1,3})\\s*%\\b", options: [.caseInsensitive])
+    private let resetParenRegex = try! NSRegularExpression(pattern: #"\((?:reset|resets)\s+([^)]+)\)"#, options: [.caseInsensitive])
+    private let resetLineRegex = try! NSRegularExpression(pattern: #"(?:reset|resets)\s*:?\s*(?:at:?\s*)?(.+)$"#, options: [.caseInsensitive])
+
+    private nonisolated let updateHandler: @Sendable (CodexUsageSnapshot) -> Void
+    private nonisolated let availabilityHandler: @Sendable (Bool) -> Void
+
+    private var process: Process?
+    private var stdinPipe: Pipe?
+    private var stdoutPipe: Pipe?
+    private var stderrPipe: Pipe?
+    private var state: State = .idle
+    private var bufferOut = Data()
+    private var bufferErr = Data()
+    private var snapshot = CodexUsageSnapshot()
+    private var shouldRun: Bool = true
+    private var visible: Bool = false
+    private var backoffSeconds: UInt64 = 1
+    private var refresherTask: Task<Void, Never>?
+
+    init(updateHandler: @escaping @Sendable (CodexUsageSnapshot) -> Void,
+         availabilityHandler: @escaping @Sendable (Bool) -> Void) {
+        self.updateHandler = updateHandler
+        self.availabilityHandler = availabilityHandler
+    }
+
+    func start() async {
+        shouldRun = true
+        refresherTask?.cancel()
+        refresherTask = Task { [weak self] in
+            guard let self else { return }
+            while await self.shouldRun {
+                await self.refreshTick()
+                let interval = await self.nextInterval()
+                try? await Task.sleep(nanoseconds: interval)
+            }
+        }
+    }
+
+    func stop() async {
+        shouldRun = false
+        refresherTask?.cancel()
+        refresherTask = nil
+    }
+
+    func setVisible(_ isVisible: Bool) {
+        visible = isVisible
+    }
+
+    func refreshNow() {
+        Task { await self.refreshTick() }
+    }
+
+    // MARK: - Core
+
+    private func ensureProcessPrimed() async {
+        if process?.isRunning == true { return }
+        await launchREPL(preferredModel: "gpt-5-nano")
+        if process?.isRunning != true {
+            await launchREPL(preferredModel: "gpt-5-mini")
+        }
+        if process?.isRunning == true {
+            backoffSeconds = 1
+            availabilityHandler(false)
+            await send("ping\n/status\n")
+        } else {
+            availabilityHandler(true)
+        }
+    }
+
+    private func launchREPL(preferredModel: String) async {
+        if state == .starting || state == .running { return }
+        state = .starting
+
+        // Build a bash -lc command to use user's login shell PATH
+        let command = "codex -m \(preferredModel)"
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["bash", "-lc", command]
+
+        var env = ProcessInfo.processInfo.environment
+        if let terminalPATH = Self.terminalPATH() { env["PATH"] = terminalPATH }
+        proc.environment = env
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        proc.standardInput = stdin
+        proc.standardOutput = stdout
+        proc.standardError = stderr
+
+        stdout.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            if !data.isEmpty {
+                Task { await self?.consume(data: data, isError: false) }
+            }
+        }
+        stderr.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            if !data.isEmpty {
+                Task { await self?.consume(data: data, isError: true) }
+            }
+        }
+        proc.terminationHandler = { [weak self] _ in
+            Task { await self?.handleTermination() }
+        }
+
+        do {
+            try proc.run()
+            process = proc
+            stdinPipe = stdin
+            stdoutPipe = stdout
+            stderrPipe = stderr
+            state = .running
+        } catch {
+            state = .idle
+        }
+    }
+
+    private func handleTermination() async {
+        state = .idle
+        stdinPipe = nil
+        stdoutPipe?.fileHandleForReading.readabilityHandler = nil
+        stderrPipe?.fileHandleForReading.readabilityHandler = nil
+        stdoutPipe = nil
+        stderrPipe = nil
+        process = nil
+        availabilityHandler(true)
+        guard shouldRun else { return }
+        // Exponential backoff restart
+        let delay = min(backoffSeconds, 60)
+        try? await Task.sleep(nanoseconds: delay * 1_000_000_000)
+        backoffSeconds = min(delay * 2, 60)
+        await ensureProcessPrimed()
+    }
+
+    private func terminateProcess() async {
+        guard let p = process else { return }
+        p.interrupt()
+        // Give it a moment, then SIGTERM if needed
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        if p.isRunning { p.terminate() }
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        // Avoid using non-existent kill() API on Process; rely on terminate.
+        if p.isRunning { p.terminate() }
+        process = nil
+        state = .idle
+    }
+
+    private func send(_ text: String) async {
+        guard state == .running, let fh = stdinPipe?.fileHandleForWriting else { return }
+        if let data = text.data(using: .utf8) {
+            // FileHandle.write(_:) is available and sufficient here.
+            fh.write(data)
+        }
+    }
+
+    private func consume(data: Data, isError: Bool) async {
+        if isError { bufferErr.append(data) } else { bufferOut.append(data) }
+        // Drain complete lines without holding an inout across await
+        let lines = drainLines(fromError: isError)
+        for line in lines {
+            await handleLine(line)
+        }
+    }
+
+    private func drainLines(fromError: Bool) -> [String] {
+        var produced: [String] = []
+        var buffer = fromError ? bufferErr : bufferOut
+        while true {
+            if let idx = buffer.firstIndex(of: 0x0a) { // newline byte
+                let lineData = buffer.subdata(in: 0..<idx)
+                buffer.removeSubrange(0...idx)
+                if let line = String(data: lineData, encoding: .utf8) {
+                    produced.append(line.trimmingCharacters(in: .whitespacesAndNewlines))
+                }
+            } else {
+                break
+            }
+        }
+        // Write back the remaining buffer
+        if fromError {
+            bufferErr = buffer
+        } else {
+            bufferOut = buffer
+        }
+        return produced
+    }
+
+    private func handleLine(_ line: String) async {
+        if line.isEmpty { return }
+        let clean = stripANSI(line)
+        let lower = clean.lowercased()
+        let isFiveHour = (lower.contains("5h") || lower.contains("5 h") || lower.contains("5-hour") || lower.contains("5 hour")) && lower.contains("limit")
+        if isFiveHour {
+            var s = snapshot
+            s.fiveHourPercent = extractPercent(from: clean) ?? s.fiveHourPercent
+            s.fiveHourResetText = extractResetText(from: clean) ?? s.fiveHourResetText
+            snapshot = s
+            updateHandler(snapshot)
+            return
+        }
+        let isWeekly = (lower.contains("weekly") && lower.contains("limit")) || lower.contains("week limit")
+        if isWeekly {
+            var s = snapshot
+            s.weekPercent = extractPercent(from: clean) ?? s.weekPercent
+            s.weekResetText = extractResetText(from: clean) ?? s.weekResetText
+            snapshot = s
+            updateHandler(snapshot)
+            return
+        }
+        if lower.hasPrefix("account:") { var s = snapshot; s.accountLine = clean; snapshot = s; updateHandler(snapshot); return }
+        if lower.hasPrefix("model:") { var s = snapshot; s.modelLine = clean; snapshot = s; updateHandler(snapshot); return }
+        if lower.hasPrefix("token usage:") { var s = snapshot; s.usageLine = clean; snapshot = s; updateHandler(snapshot); return }
+    }
+
+    private func extractPercent(from line: String) -> Int? {
+        let range = NSRange(location: 0, length: (line as NSString).length)
+        if let m = percentRegex.firstMatch(in: line, options: [], range: range), m.numberOfRanges >= 2 {
+            let str = (line as NSString).substring(with: m.range(at: 1))
+            return Int(str)
+        }
+        return nil
+    }
+
+    private func extractResetText(from line: String) -> String? {
+        let ns = line as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        if let m = resetParenRegex.firstMatch(in: line, options: [], range: range), m.numberOfRanges >= 2 {
+            return ns.substring(with: m.range(at: 1)).trimmingCharacters(in: .whitespaces)
+        }
+        if let m = resetLineRegex.firstMatch(in: line, options: [], range: range), m.numberOfRanges >= 2 {
+            return ns.substring(with: m.range(at: 1)).trimmingCharacters(in: .whitespaces)
+        }
+        return nil
+    }
+
+    private func refreshTick() async {
+        // Log-probe path: scan latest JSONL for token_count rate_limits
+        let root = sessionsRoot()
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: root.path, isDirectory: &isDir)
+        guard exists && isDir.boolValue else {
+            availabilityHandler(true)
+            return
+        }
+        availabilityHandler(false)
+        if let summary = probeLatestRateLimits(root: root) {
+            var s = snapshot
+            if let p = summary.fiveHour.usedPercent { s.fiveHourPercent = clampPercent(p) }
+            if let p = summary.weekly.usedPercent { s.weekPercent = clampPercent(p) }
+            s.fiveHourResetText = formatReset(summary.fiveHour.resetAt, now: Date())
+            s.weekResetText = formatReset(summary.weekly.resetAt, now: Date())
+            s.usageLine = summary.stale ? "Usage is stale (>3m)" : nil
+            snapshot = s
+            updateHandler(snapshot)
+        }
+    }
+
+    private func nextInterval() -> UInt64 {
+        // Default: 300s when not visible; 60s when visible.
+        var seconds: UInt64 = visible ? 60 : 300
+        let urgent = isUrgent()
+        if urgent { seconds = 60 }
+        return seconds * 1_000_000_000
+    }
+
+    private func isUrgent() -> Bool {
+        if snapshot.fiveHourPercent >= 80 { return true }
+        if let reset = parseResetDate(snapshot.fiveHourResetText) {
+            let now = Date()
+            if reset.timeIntervalSince(now) <= 15 * 60 { return true }
+        }
+        return false
+    }
+
+    // MARK: - Log probe helpers
+
+    private func sessionsRoot() -> URL {
+        if let override = UserDefaults.standard.string(forKey: "SessionsRootOverride"), !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        if let env = ProcessInfo.processInfo.environment["CODEX_HOME"], !env.isEmpty {
+            return URL(fileURLWithPath: env).appendingPathComponent("sessions")
+        }
+        return URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".codex/sessions")
+    }
+
+    private func probeLatestRateLimits(root: URL) -> RateLimitSummary? {
+        let candidates = findCandidateFiles(root: root, daysBack: 7, limit: 12)
+        for url in candidates {
+            if let summary = parseTokenCountTail(url: url) { return summary }
+        }
+        return RateLimitSummary(
+            fiveHour: RateLimitWindow(usedPercent: nil, resetAt: nil, windowMinutes: nil),
+            weekly: RateLimitWindow(usedPercent: nil, resetAt: nil, windowMinutes: nil),
+            eventTimestamp: nil,
+            stale: true,
+            sourceFile: nil
+        )
+    }
+
+    private func findCandidateFiles(root: URL, daysBack: Int, limit: Int) -> [URL] {
+        var urls: [URL] = []
+        let cal = Calendar(identifier: .gregorian)
+        let now = Date()
+        let fm = FileManager.default
+        for offset in 0...daysBack {
+            guard let day = cal.date(byAdding: .day, value: -offset, to: now) else { continue }
+            let comps = cal.dateComponents([.year, .month, .day], from: day)
+            guard let y = comps.year, let m = comps.month, let d = comps.day else { continue }
+            let folder = root
+                .appendingPathComponent(String(format: "%04d", y))
+                .appendingPathComponent(String(format: "%02d", m))
+                .appendingPathComponent(String(format: "%02d", d))
+            var isDir: ObjCBool = false
+            if fm.fileExists(atPath: folder.path, isDirectory: &isDir), isDir.boolValue {
+                if let items = try? fm.contentsOfDirectory(at: folder, includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey], options: [.skipsHiddenFiles]) {
+                    for u in items where u.lastPathComponent.hasPrefix("rollout-") && u.pathExtension.lowercased() == "jsonl" {
+                        urls.append(u)
+                    }
+                }
+            }
+            if urls.count >= limit { break }
+        }
+        urls.sort { a, b in
+            let da = (try? a.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? Date.distantPast
+            let db = (try? b.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? Date.distantPast
+            return da > db
+        }
+        if urls.count > limit { urls = Array(urls.prefix(limit)) }
+        return urls
+    }
+
+    private func parseTokenCountTail(url: URL) -> RateLimitSummary? {
+        guard let lines = tailLines(url: url, maxBytes: 512 * 1024) else { return nil }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        for raw in lines.reversed() {
+            guard let data = raw.data(using: .utf8) else { continue }
+            guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+            guard (obj["type"] as? String) == "event_msg" else { continue }
+            guard let payload = obj["payload"] as? [String: Any] else { continue }
+            guard (payload["type"] as? String) == "token_count" else { continue }
+
+            var createdAt: Date? = nil
+            if let s = obj["created_at"] as? String { createdAt = iso.date(from: s) }
+            if createdAt == nil, let s = payload["created_at"] as? String { createdAt = iso.date(from: s) }
+            let created = createdAt ?? Date()
+
+            guard let rate = payload["rate_limits"] as? [String: Any] else { continue }
+            let primary = rate["primary"] as? [String: Any]
+            let secondary = rate["secondary"] as? [String: Any]
+
+            let five = decodeWindow(primary, created: created)
+            let week = decodeWindow(secondary, created: created)
+            let stale = Date().timeIntervalSince(created) > 3 * 60
+            return RateLimitSummary(fiveHour: five, weekly: week, eventTimestamp: created, stale: stale, sourceFile: url)
+        }
+        return nil
+    }
+
+    private func decodeWindow(_ dict: [String: Any]?, created: Date) -> RateLimitWindow {
+        guard let dict else { return RateLimitWindow(usedPercent: nil, resetAt: nil, windowMinutes: nil) }
+        let used = (dict["used_percent"] as? Double).map { Int(($0).rounded()) }
+        let resets = (dict["resets_in_seconds"] as? Double) ?? (dict["resets_in_seconds"] as? NSNumber)?.doubleValue
+        let minutes = dict["window_minutes"] as? Int
+        let resetAt = resets.map { created.addingTimeInterval($0) }
+        return RateLimitWindow(usedPercent: used, resetAt: resetAt, windowMinutes: minutes)
+    }
+
+    private func tailLines(url: URL, maxBytes: Int) -> [String]? {
+        guard let fh = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? fh.close() }
+        let attrs = (try? FileManager.default.attributesOfItem(atPath: url.path)) ?? [:]
+        let fileSize = (attrs[.size] as? NSNumber)?.intValue ?? 0
+        let toRead = min(maxBytes, max(0, fileSize))
+        let startOffset = UInt64(max(0, fileSize - toRead))
+        do { try fh.seek(toOffset: startOffset) } catch { return nil }
+        let data = (try? fh.readToEnd()) ?? Data()
+        guard !data.isEmpty else { return [] }
+        var text = String(decoding: data, as: UTF8.self)
+        if !text.hasSuffix("\n") { if let lastNL = text.lastIndex(of: "\n") { text = String(text[..<lastNL]) } }
+        return text.split(separator: "\n", omittingEmptySubsequences: true).map { String($0) }
+    }
+
+    private func formatReset(_ date: Date?, now: Date) -> String {
+        guard let date else { return "" }
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(identifier: "America/Los_Angeles")
+        df.dateFormat = "yyyy-MM-dd HH:mm"
+        let ts = df.string(from: date)
+        let delta = max(0, Int(date.timeIntervalSince(now)))
+        let days = delta / 86_400
+        let hours = (delta % 86_400) / 3600
+        let mins = (delta % 3600) / 60
+        var parts: [String] = []
+        if days > 0 { parts.append("\(days)d") }
+        if hours > 0 || days > 0 { parts.append("\(hours)h") }
+        parts.append("\(mins)m")
+        return "\(ts) (in \(parts.joined(separator: " ")))"
+    }
+
+    private func clampPercent(_ v: Int) -> Int { max(0, min(100, v)) }
+
+    private func parseResetDate(_ text: String) -> Date? {
+        guard !text.isEmpty else { return nil }
+        let tz = TimeZone(identifier: "America/Los_Angeles")
+
+        // Try a few tolerant formats
+        let fmts = [
+            "HH:mm",
+            "h:mm a",
+            "MMM d, yyyy h:mm a",
+            "MMM d, yyyy HH:mm",
+            "d MMM yyyy HH:mm",
+            "HH:mm 'on' d MMM",
+            "h:mm a 'on' d MMM"
+        ]
+        for f in fmts {
+            let df = DateFormatter()
+            df.locale = Locale(identifier: "en_US_POSIX")
+            df.timeZone = tz
+            df.dateFormat = f
+            if let d = df.date(from: text) { return d }
+        }
+        return nil
+    }
+
+    private func stripANSI(_ s: String) -> String {
+        var result = s
+        // Remove CSI escape sequences: ESC [ ... final byte in @-~
+        if let re = try? NSRegularExpression(pattern: "\u{001B}\\[[0-9;?]*[ -/]*[@-~]", options: []) {
+            result = re.stringByReplacingMatches(in: result, options: [], range: NSRange(location: 0, length: (result as NSString).length), withTemplate: "")
+        }
+        // Remove OSC sequences ending with BEL: ESC ] ... BEL
+        if let re2 = try? NSRegularExpression(pattern: "\u{001B}\\][^\u{0007}]*\u{0007}", options: []) {
+            result = re2.stringByReplacingMatches(in: result, options: [], range: NSRange(location: 0, length: (result as NSString).length), withTemplate: "")
+        }
+        return result
+    }
+
+    private static func terminalPATH() -> String? {
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: shell)
+        p.arguments = ["-lic", "echo -n \"$PATH\""]
+        let out = Pipe()
+        p.standardOutput = out
+        p.standardError = Pipe()
+        do { try p.run() } catch { return nil }
+        p.waitUntilExit()
+        guard p.terminationStatus == 0 else { return nil }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (path?.isEmpty == false) ? path : nil
+    }
+}

--- a/AgentSessions/CodexStatus/UsageStripView.swift
+++ b/AgentSessions/CodexStatus/UsageStripView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+// ILLUSTRATIVE: Compact footer usage strip with two meters
+struct UsageStripView: View {
+    @ObservedObject var status: CodexUsageModel
+    @State private var showPopover: Bool = false
+
+    var body: some View {
+        HStack(spacing: 16) {
+            UsageMeter(title: "5h", percent: status.fiveHourPercent, reset: status.fiveHourResetText)
+            UsageMeter(title: "Wk", percent: status.weekPercent, reset: status.weekResetText)
+            Spacer(minLength: 0)
+            if let line = status.usageLine, !line.isEmpty {
+                Text(line).font(.caption).foregroundStyle(.secondary)
+            }
+            Button(action: { showPopover.toggle() }) {
+                Image(systemName: "info.circle")
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: $showPopover, arrowEdge: .top) {
+                DetailPopover(status: status)
+                    .frame(width: 320)
+                    .padding(12)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.thickMaterial)
+        .onAppear { status.setVisible(true) }
+        .onDisappear { status.setVisible(false) }
+    }
+}
+
+private struct UsageMeter: View {
+    let title: String
+    let percent: Int
+    let reset: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title).font(.footnote).bold()
+            ProgressView(value: Double(percent), total: 100)
+                .frame(width: 140)
+            Text("\(percent)%").font(.footnote).monospacedDigit()
+        }
+        .help("Resets: \(reset.isEmpty ? "unknown" : reset)")
+    }
+}
+
+private struct DetailPopover: View {
+    @ObservedObject var status: CodexUsageModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                Text("5h").font(.caption).bold()
+                ProgressView(value: Double(status.fiveHourPercent), total: 100)
+                Text("\(status.fiveHourPercent)%").font(.caption).monospacedDigit()
+            }
+            Text("Reset: \(status.fiveHourResetText.isEmpty ? "unknown" : status.fiveHourResetText)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            HStack(spacing: 12) {
+                Text("Wk").font(.caption).bold()
+                ProgressView(value: Double(status.weekPercent), total: 100)
+                Text("\(status.weekPercent)%").font(.caption).monospacedDigit()
+            }
+            Text("Reset: \(status.weekResetText.isEmpty ? "unknown" : status.weekResetText)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let model = status.modelLine, !model.isEmpty {
+                Divider()
+                Text(model).font(.caption)
+            }
+            if let acct = status.accountLine, !acct.isEmpty {
+                Text(acct).font(.caption)
+            }
+            if let usage = status.usageLine, !usage.isEmpty {
+                Text(usage).font(.caption)
+            }
+        }
+    }
+}

--- a/AgentSessions/Views/PreferencesView.swift
+++ b/AgentSessions/Views/PreferencesView.swift
@@ -7,6 +7,7 @@ struct PreferencesView: View {
     @EnvironmentObject var indexer: SessionIndexer
     @State private var selectedTab: PreferencesTab?
     @ObservedObject private var resumeSettings = CodexResumeSettings.shared
+    @AppStorage("ShowUsageStrip") private var showUsageStrip: Bool = false
 
     private let initialResumeSelection: String?
 
@@ -219,6 +220,21 @@ struct PreferencesView: View {
                             .font(.caption)
                             .foregroundStyle(.red)
                     }
+                }
+            }
+
+            sectionHeader("Usage Strip")
+            VStack(alignment: .leading, spacing: 12) {
+                toggleRow("Show in-app Codex usage strip", isOn: $showUsageStrip)
+                HStack(spacing: 12) {
+                    Button("Refresh Probe") {
+                        CodexUsageModel.shared.refreshNow()
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(!showUsageStrip)
+                    Text("Parses recent Codex session logs for rate limits.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
 


### PR DESCRIPTION
This PR switches the in‑app usage limits to a non‑interactive, low‑overhead log probe.

Summary
- Source: reads the latest `rollout-*.jsonl` under `~/.codex/sessions/**` (or `CODEX_HOME/sessions`, or `SessionsRootOverride`).
- Data: parses the most recent `event_msg` with `payload.type == "token_count"` and extracts `rate_limits.primary/secondary`.
- Output: two meters (5h + weekly) with reset times formatted as `YYYY-MM-DD HH:mm (in Xd Yh Zm)` using America/Los_Angeles.
- No REPL, no PTY, no `/status` calls. CPU remains minimal.

Changes
- Service (log-tail probe)
  - `AgentSessions/CodexStatus/CodexStatusService.swift`
    - Replaced REPL polling with a tail reader that scans recent session files (up to ~12 recent day folders, last ~512KB per file), reverse‑searching for the first `token_count` event.
    - New helpers: candidate discovery, tail reading, JSON parsing, freshness check, reset formatting, and urgency policy.
    - New models: `RateLimitWindow`, `RateLimitSummary`.
- UI
  - `UsageStripView` remains the compact footer; consumes the same published fields.
  - `PreferencesView`: button label updated to “Refresh Probe”.

Refresh policy
- 60s when the strip is visible.
- 300s when not visible.
- Urgency: if 5h ≥80% or the 5h reset is within 15m, refresh at 60s until safe.

Resilience
- Missing/older logs: marks values as stale (>3m) and leaves meters at N/A/0%; `usageLine` shows a gentle “Usage is stale (>3m)”.
- Tolerates partial JSON lines; skips parse errors.

Rationale
- Codex 0.42 REPL expects a TTY; piping `/status` is brittle, and we don’t want to ship a PTY dependency.
- This path relies entirely on existing JSONL logs and avoids background REPL processes.

How to test
1) Preferences → Usage Strip → enable the toggle.
2) If your sessions aren’t under the default path, set the sessions folder (already supported via `SessionsRootOverride`).
3) Click “Refresh Probe” to force a pass.
4) Run Codex and send a message to emit a fresh `token_count` (most models do this early in the session). The strip should populate within the next tick.

Follow‑ups (optional)
- Add a security‑scoped bookmark flow for sandboxed builds to grant access to `~/.codex/sessions`.
- Small stale/CLI‑unavailable tooltip in the strip for clarity.
- If Codex exposes a future non‑interactive `codex status`, we can add it as a primary path and keep logs as fallback.

Non‑goals
- No menu bar extra, no titlebar accessory.

Thanks!
