### PR TITLE
Trust docs: license + security posture + privacy + contributing

### DIFF
--- a/AgentSessions/Views/Preferences/PreferencesView+About.swift
+++ b/AgentSessions/Views/Preferences/PreferencesView+About.swift
@@ -35,6 +35,20 @@ extension PreferencesView {
                     }
                 }
 
+                labeledRow("Security & Privacy:") {
+                    Button("Security & Privacy") {
+                        UpdateCheckModel.shared.openURL("https://github.com/jazzyalex/agent-sessions/blob/main/docs/security.md")
+                    }
+                    .buttonStyle(.link)
+                }
+
+                labeledRow("License:") {
+                    Button("MIT License") {
+                        UpdateCheckModel.shared.openURL("https://github.com/jazzyalex/agent-sessions/blob/main/LICENSE")
+                    }
+                    .buttonStyle(.link)
+                }
+
                 labeledRow("Website:") {
                     Button("jazzyalex.github.io/agent-sessions") {
                         UpdateCheckModel.shared.openURL("https://jazzyalex.github.io/agent-sessions/")

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 </tr>
 </table>
 
+- License: MIT
+- Security & Privacy: Local-only. No telemetry. Details: `docs/security.md`
+
 <p align="center">
   <a href="https://github.com/jazzyalex/agent-sessions/releases/download/v2.9.1/AgentSessions-2.9.1.dmg"><b>Download Agent Sessions 2.9.1 (DMG)</b></a>
   •
@@ -34,6 +37,11 @@
 
 Agent Sessions 2 brings **Codex CLI**, **Claude Code**, **Gemini CLI**, **GitHub Copilot CLI**, and **Droid (Factory CLI)** together in one interface.
 Look up any past session — even the ancient ones `/resume` can't show — or browse visually to find that perfect prompt or code snippet, then instantly copy or resume it.
+
+## Trust
+- `docs/PRIVACY.md`
+- `docs/security.md`
+- `LICENSE`
 
 <div align="center">
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Dates: Normalize timestamps (usage reset times, session dates, analytics labels, and transcript timestamps) to follow system locale and 12/24-hour settings.
 - Appearance: Add a toolbar toggle for Dark/Light mode and View menu actions for Toggle Dark/Light and Use System Appearance.
+- Preferences: Add quick links to Security & Privacy and License in Settings → About.
 
 ## [2.9.1] - 2025-12-29
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Build
+1. macOS version: <min version>
+2. Xcode version: <version>
+3. Open `AgentSessions.xcodeproj` (or .xcworkspace)
+4. Build and run the `AgentSessions` target.
+
+## Project structure
+- Parsers: <path>
+- Session sources registry: <path>
+- Search/index: <path>
+- UI: <path>
+
+## Adding a new agent source
+1. Add a new SessionSource case.
+2. Implement parser + discovery.
+3. Add fixtures under <path>.
+4. Add/adjust tests (if any).
+
+## Pull requests
+- Keep PRs focused.
+- Include a short “before/after” note and test plan.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,20 @@
+# Privacy Policy (Agent Sessions)
+
+Agent Sessions is a local-first app.
+
+## Data collection
+- No telemetry
+- No analytics
+- No remote logging
+- No advertising identifiers
+
+## Data processing
+- Session logs are read from local folders you choose.
+- The app may build a local index/database to enable search and navigation.
+
+## Data sharing
+- No data is sent to any server.
+- The only network activity is optional update checking (Sparkle), if enabled.
+
+## Contact
+jazzyalex@gmail.com

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,6 +14,13 @@ This runbook provides a **fully automated deployment process** with comprehensiv
 - `tools/release/deploy release <VERSION>`
 - `tools/release/deploy verify <VERSION>`
 
+## Sparkle Update Integrity (Appcast + Signatures)
+
+- **Appcast file**: `docs/appcast.xml` (committed to `main`)
+- **Served from**: GitHub Pages over HTTPS at `https://jazzyalex.github.io/agent-sessions/appcast.xml`
+- **Update payloads**: DMGs are hosted on GitHub Releases over HTTPS (the appcast `enclosure url` should point to `https://github.com/jazzyalex/agent-sessions/releases/...`)
+- **Signing (recommended by Sparkle)**: Appcast generation uses Sparkle’s `generate_appcast`, which produces EdDSA signatures for update enclosures.
+
 **Key environment flags**:
 - `SKIP_CONFIRM=1` — make bump and release flows unattended (suppresses confirmation prompts where supported).
 - `NOTARIZE_SYNC=1` — use legacy blocking notarization instead of background polling.
@@ -72,7 +79,7 @@ Full deployment pipeline with enhanced safety:
 - ✅ **Enhanced pre-flight checks** (git state, version validation, build numbers)
 - ✅ **Build, sign, and notarize** (Apple Developer ID)
 - ✅ **DMG smoke testing** (mount, verify signature, check version)
-- ✅ **Sparkle appcast generation** (EdDSA signatures)
+- ✅ **Sparkle appcast generation** (Sparkle `generate_appcast`, EdDSA signatures)
 - ✅ **GitHub release creation** (idempotent, can re-run)
 - ✅ **Homebrew cask update** (via GitHub API)
 - ✅ **Network retry logic** (3 attempts, 5s backoff)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,19 @@
+# Security (Agent Sessions)
+
+Agent Sessions is a local-first app. Session data stays on your Mac and is not sent to a server.
+
+## Data access model
+- The app reads session logs from local folders you choose (or the default CLI locations).
+- The app may build a local index/database to enable search and navigation.
+
+## Network activity
+- The app does not include telemetry, analytics, or remote logging.
+- The only network activity is optional update checking (Sparkle), if enabled.
+
+## Update integrity (Sparkle)
+- Update checks use Sparkle.
+- Updates are signed (EdDSA signatures generated via Sparkle `generate_appcast`).
+- The appcast is served over HTTPS.
+
+## Reporting
+If you believe you have found a security issue, contact `jazzyalex@gmail.com` with details and reproduction steps.

--- a/docs/summaries/2026-01.md
+++ b/docs/summaries/2026-01.md
@@ -1,3 +1,4 @@
 ## January 2026
 
 - Appearance: Added a toolbar button to toggle Dark/Light mode and View menu actions for Toggle Dark/Light and Use System Appearance.
+- Preferences: Added Security & Privacy and License links in Settings → About.


### PR DESCRIPTION
Adds audit-friendly trust links and posture:
- README: License + Security & Privacy bullets and Trust section
- Docs: privacy policy, contributing guide, security posture, Sparkle update integrity notes
- Preferences → About: quick links to Security & Privacy and License

Test plan:
- Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project AgentSessions.xcodeproj -scheme AgentSessions -configuration Debug -destination platform=macOS build

Resolve Package Graph


Resolved source packages:
  Sparkle: https://github.com/sparkle-project/Sparkle @ 2.8.0

ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (2 targets)
    Target 'AgentSessions' in project 'AgentSessions'
        ➜ Explicit dependency on target 'Sparkle' in project 'Sparkle'
    Target 'Sparkle' in project 'Sparkle' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details

Build description signature: bad12a1cab877b5882c33f705dc71681
Build description path: /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/XCBuildData/bad12a1cab877b5882c33f705dc71681.xcbuilddata
ProcessProductPackaging /Users/alexm/Repository/Codex-History/AgentSessions/AgentSessions.entitlements /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/AgentSessions.app.xcent (in target 'AgentSessions' from project 'AgentSessions')
    cd /Users/alexm/Repository/Codex-History
    
    Entitlements:
    
    {
    "com.apple.security.get-task-allow" = 1;
}
    
    builtin-productPackagingUtility /Users/alexm/Repository/Codex-History/AgentSessions/AgentSessions.entitlements -entitlements -format xml -o /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/AgentSessions.app.xcent

ProcessProductPackagingDER /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/AgentSessions.app.xcent /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/AgentSessions.app.xcent.der (in target 'AgentSessions' from project 'AgentSessions')
    cd /Users/alexm/Repository/Codex-History
    /usr/bin/derq query -f xml -i /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/AgentSessions.app.xcent -o /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/AgentSessions.app.xcent.der --raw

ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk /Users/alexm/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.2-25C57-00fa09913b459cbbc988d1f6730289ae.sdkstatcache
    cd /Users/alexm/Repository/Codex-History/AgentSessions.xcodeproj
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk -o /Users/alexm/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.2-25C57-00fa09913b459cbbc988d1f6730289ae.sdkstatcache

CopySwiftLibs /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app (in target 'AgentSessions' from project 'AgentSessions')
    cd /Users/alexm/Repository/Codex-History
    builtin-swiftStdLibTool --copy --verbose --sign - --scan-executable /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/MacOS/AgentSessions.debug.dylib --scan-folder /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/Frameworks --scan-folder /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/PlugIns --scan-folder /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/Library/SystemExtensions --scan-folder /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/Frameworks --strip-bitcode --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span

ProcessInfoPlistFile /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/Info.plist /Users/alexm/Repository/Codex-History/AgentSessions/Info.plist (in target 'AgentSessions' from project 'AgentSessions')
    cd /Users/alexm/Repository/Codex-History
    builtin-infoPlistUtility /Users/alexm/Repository/Codex-History/AgentSessions/Info.plist -producttype com.apple.product-type.application -genpkginfo /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/PkgInfo -expandbuildsettings -platform macosx -additionalcontentfile /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/assetcatalog_generated_info.plist -scanforprivacyfile /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/Frameworks/Sparkle.framework -o /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app/Contents/Info.plist

CodeSign /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app (in target 'AgentSessions' from project 'AgentSessions')
    cd /Users/alexm/Repository/Codex-History
    
    Signing Identity:     "Sign to Run Locally"
    
    /usr/bin/codesign --force --sign - --entitlements /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Intermediates.noindex/AgentSessions.build/Debug/AgentSessions.build/AgentSessions.app.xcent --timestamp\=none --generate-entitlement-der /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app
/Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app: replacing existing signature

Validate /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app (in target 'AgentSessions' from project 'AgentSessions')
    cd /Users/alexm/Repository/Codex-History
    builtin-validationUtility /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app -no-validate-extension -infoplist-subpath Contents/Info.plist

RegisterWithLaunchServices /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app (in target 'AgentSessions' from project 'AgentSessions')
    cd /Users/alexm/Repository/Codex-History
    /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted /Users/alexm/Library/Developer/Xcode/DerivedData/AgentSessions-gwsclzavdbgeubaxduodxdziqbpo/Build/Products/Debug/AgentSessions.app

** BUILD SUCCEEDED **