### PR TITLE
perf: eliminate redundant SwiftUI body evaluations during indexing

### DIFF
--- a/AgentSessions/Onboarding/Views/OnboardingSheetView.swift
+++ b/AgentSessions/Onboarding/Views/OnboardingSheetView.swift
@@ -4,13 +4,13 @@ import AppKit
 struct OnboardingSheetView: View {
     let content: OnboardingContent
     @ObservedObject var coordinator: OnboardingCoordinator
-    @ObservedObject var codexIndexer: SessionIndexer
-    @ObservedObject var claudeIndexer: ClaudeSessionIndexer
-    @ObservedObject var geminiIndexer: GeminiSessionIndexer
-    @ObservedObject var opencodeIndexer: OpenCodeSessionIndexer
-    @ObservedObject var copilotIndexer: CopilotSessionIndexer
-    @ObservedObject var droidIndexer: DroidSessionIndexer
-    @ObservedObject var openclawIndexer: OpenClawSessionIndexer
+    let codexIndexer: SessionIndexer
+    let claudeIndexer: ClaudeSessionIndexer
+    let geminiIndexer: GeminiSessionIndexer
+    let opencodeIndexer: OpenCodeSessionIndexer
+    let copilotIndexer: CopilotSessionIndexer
+    let droidIndexer: DroidSessionIndexer
+    let openclawIndexer: OpenClawSessionIndexer
     @ObservedObject var codexUsageModel: CodexUsageModel
     @ObservedObject var claudeUsageModel: ClaudeUsageModel
 

--- a/AgentSessions/Services/ClaudeSessionParser.swift
+++ b/AgentSessions/Services/ClaudeSessionParser.swift
@@ -938,18 +938,22 @@ final class ClaudeSessionParser {
             return Date(timeIntervalSince1970: normalizeEpochSeconds(Double(num)))
         }
         if let str = value as? String {
-            // Try ISO8601
-            let iso = ISO8601DateFormatter()
-            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            if let date = iso.date(from: str) {
-                return date
-            }
-            // Try without fractional seconds
-            iso.formatOptions = [.withInternetDateTime]
-            return iso.date(from: str)
+            if let date = isoFracFormatter.date(from: str) { return date }
+            return isoNoFracFormatter.date(from: str)
         }
         return nil
     }
+
+    private static let isoFracFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let isoNoFracFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
 
     private static func normalizeEpochSeconds(_ value: Double) -> Double {
         if value > 1e14 { return value / 1_000_000 }  // microseconds

--- a/AgentSessions/Services/SessionIndexer.swift
+++ b/AgentSessions/Services/SessionIndexer.swift
@@ -2179,26 +2179,37 @@ final class SessionIndexer: ObservableObject {
             if CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: s)) {
                 if let val = Double(s) { return Date(timeIntervalSince1970: normalizeEpochSeconds(val)) }
             }
-            // ISO8601 with or without fractional seconds
-            let iso = ISO8601DateFormatter()
-            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            if let d = iso.date(from: s) { return d }
-            let isoNoFrac = ISO8601DateFormatter()
-            isoNoFrac.formatOptions = [.withInternetDateTime]
-            if let d = isoNoFrac.date(from: s) { return d }
+            // ISO8601 with or without fractional seconds (use cached formatters)
+            if let d = Self.isoFracFormatter.date(from: s) { return d }
+            if let d = Self.isoNoFracFormatter.date(from: s) { return d }
             // Common fallbacks
-            let fmts = [
-                "yyyy-MM-dd HH:mm:ssZZZZZ",
-                "yyyy-MM-dd HH:mm:ss",
-                "yyyy/MM/dd HH:mm:ssZZZZZ",
-                "yyyy/MM/dd HH:mm:ss"
-            ]
-            let df = DateFormatter()
-            df.locale = Locale(identifier: "en_US_POSIX")
-            for f in fmts { df.dateFormat = f; if let d = df.date(from: s) { return d } }
+            for fmt in Self.fallbackDateFormatters {
+                if let d = fmt.date(from: s) { return d }
+            }
         }
         return nil
     }
+
+    // Cached date formatters — allocation is expensive, reuse across all parse calls
+    private static let isoFracFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let isoNoFracFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+    private static let fallbackDateFormatters: [DateFormatter] = {
+        ["yyyy-MM-dd HH:mm:ssZZZZZ", "yyyy-MM-dd HH:mm:ss",
+         "yyyy/MM/dd HH:mm:ssZZZZZ", "yyyy/MM/dd HH:mm:ss"].map { fmt in
+            let df = DateFormatter()
+            df.locale = Locale(identifier: "en_US_POSIX")
+            df.dateFormat = fmt
+            return df
+        }
+    }()
 
     private static func normalizeEpochSeconds(_ value: Double) -> Double {
         // Heuristic: >1e14 → microseconds; >1e11 → milliseconds; else seconds

--- a/AgentSessions/Views/UnifiedSessionsView.swift
+++ b/AgentSessions/Views/UnifiedSessionsView.swift
@@ -203,13 +203,13 @@ private struct WindowKeyObserver: NSViewRepresentable {
 
 struct UnifiedSessionsView: View {
     @ObservedObject var unified: UnifiedSessionIndexer
-    @ObservedObject var codexIndexer: SessionIndexer
-    @ObservedObject var claudeIndexer: ClaudeSessionIndexer
-    @ObservedObject var geminiIndexer: GeminiSessionIndexer
-    @ObservedObject var opencodeIndexer: OpenCodeSessionIndexer
-    @ObservedObject var copilotIndexer: CopilotSessionIndexer
-    @ObservedObject var droidIndexer: DroidSessionIndexer
-    @ObservedObject var openclawIndexer: OpenClawSessionIndexer
+    let codexIndexer: SessionIndexer
+    let claudeIndexer: ClaudeSessionIndexer
+    let geminiIndexer: GeminiSessionIndexer
+    let opencodeIndexer: OpenCodeSessionIndexer
+    let copilotIndexer: CopilotSessionIndexer
+    let droidIndexer: DroidSessionIndexer
+    let openclawIndexer: OpenClawSessionIndexer
     @EnvironmentObject var codexUsageModel: CodexUsageModel
     @EnvironmentObject var claudeUsageModel: ClaudeUsageModel
     @EnvironmentObject var activeCodexSessions: CodexActiveSessionsModel
@@ -2536,13 +2536,13 @@ private struct LayoutToggleButton: View {
 private struct TranscriptHostView: View {
     let kind: SessionSource
     let selection: String?
-    @ObservedObject var codexIndexer: SessionIndexer
-    @ObservedObject var claudeIndexer: ClaudeSessionIndexer
-    @ObservedObject var geminiIndexer: GeminiSessionIndexer
-    @ObservedObject var opencodeIndexer: OpenCodeSessionIndexer
-    @ObservedObject var copilotIndexer: CopilotSessionIndexer
-    @ObservedObject var droidIndexer: DroidSessionIndexer
-    @ObservedObject var openclawIndexer: OpenClawSessionIndexer
+    let codexIndexer: SessionIndexer
+    let claudeIndexer: ClaudeSessionIndexer
+    let geminiIndexer: GeminiSessionIndexer
+    let opencodeIndexer: OpenCodeSessionIndexer
+    let copilotIndexer: CopilotSessionIndexer
+    let droidIndexer: DroidSessionIndexer
+    let openclawIndexer: OpenClawSessionIndexer
 
     var body: some View {
         ZStack { // keep one stable container to avoid split reset


### PR DESCRIPTION
## Summary

- Replace `@ObservedObject` with `let` for the 7 per-agent indexer properties in `UnifiedSessionsView`, `TranscriptHostView`, and `OnboardingSheetView`. These views read session data through `UnifiedSessionIndexer`, not directly from the individual indexers — but `@ObservedObject` causes a body re-evaluation every time any indexer publishes, which cascades to ~700+ redundant evaluations per indexing cycle.
- Cache `ISO8601DateFormatter` and `DateFormatter` instances as statics in `SessionIndexer` and `ClaudeSessionParser` instead of allocating new ones per call in the date parsing hot path.

## Context

I was seeing sustained beachball during the initial indexing pass (~1400 JSONL files across 7 agent types). A `sample` profile showed the main thread was dominated by repeated `body.getter` calls in `UnifiedSessionsView`, driven by `objectWillChange` notifications from indexers the views don't actually read from.

After the `@ObservedObject` → `let` change, a 10-second sample during indexing showed 83% idle on main thread with single-digit body evaluations — versus hundreds before.

## Test plan

- 550 tests pass, 0 failures
- Verified with `sample` profiling during cold-start indexing of a large session directory
- No functional change — `let` still allows passing the indexers to child views and accessing their properties; it only removes the automatic SwiftUI observation subscription