### PR TITLE
Add CodeBuddy and WorkBuddy session support

### DIFF
--- a/AgentSessions.xcodeproj/project.pbxproj
+++ b/AgentSessions.xcodeproj/project.pbxproj
@@ -115,6 +115,9 @@
 		65EB88B78C3C117848D9BD06 /* SessionFilterShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC3DE188DC2AB5740BACF57 /* SessionFilterShims.swift */; };
 		67886527530D62D0C779167B /* ClaudeOAuthTokenResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445097A5E6BE27C7176AA8D0 /* ClaudeOAuthTokenResolver.swift */; };
 		6829C28DA0E1BEE5984B8599 /* DroidSessionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC5DFBBBA1745F69422B117 /* DroidSessionParserTests.swift */; };
+		B0000BUDY0B000100000001 /* BuddySessionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0000BUDY0A000100000001 /* BuddySessionParserTests.swift */; };
+		B0000BUDY0B000100000002 /* BuddySessionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0000BUDY0A000100000002 /* BuddySessionDiscoveryTests.swift */; };
+		B0000BUDY0B000100000003 /* SearchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0000BUDY0A000100000003 /* SearchCoordinatorTests.swift */; };
 		69FB59BA95065BDD9A8D630A /* ClaudeStatusServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558A02C67774ABC59CE8CC46 /* ClaudeStatusServiceTests.swift */; };
 		6A156D8CF9EAF097967F14E9 /* CopilotResumeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9587FF4D9D4B4CAB9167BA /* CopilotResumeCoordinator.swift */; };
 		6BD6D6A2A10EAE1215D091FC /* CursorResumeCommandBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5110A5BF02ABA14BB8B0AE6 /* CursorResumeCommandBuilderTests.swift */; };
@@ -317,6 +320,10 @@
 		EA6B3DE2F27F8FECF6357AAF /* AgentCockpitHUDRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03802C5C096CB36BC86F824C /* AgentCockpitHUDRowView.swift */; };
 		EB107C462E1C34E94A9BE16E /* CrashEmailDraftBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F809F7DFDB78DC70A32C3E /* CrashEmailDraftBuilder.swift */; };
 		EC762372C84091AFA2F77ECD /* CursorSessionIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE556B1D5555A64D3FE9C459 /* CursorSessionIndexer.swift */; };
+		B7D1A1000001000000000001 /* BuddySessionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D1A2000001000000000001 /* BuddySessionDiscovery.swift */; };
+		B7D1A1000002000000000001 /* BuddySessionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D1A2000002000000000001 /* BuddySessionParser.swift */; };
+		B7D1A1000003000000000001 /* BuddySessionIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D1A2000003000000000001 /* BuddySessionIndexer.swift */; };
+		B7D1A1000004000000000001 /* BuddyTranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D1A2000004000000000001 /* BuddyTranscriptView.swift */; };
 		EFB738C2A9060852B3E98D4A /* CodexSessionImagesGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984DB58B4EDFDA087B0B1623 /* CodexSessionImagesGalleryView.swift */; };
 		F0001909B140D84305F63FA1 /* codex_052_raw.jsonl in Resources */ = {isa = PBXBuildFile; fileRef = ABFD9C178275CA23FCE6B3DE /* codex_052_raw.jsonl */; };
 		F0BC877DF9F93DD51B379288 /* GeminiInlineDataImageScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAA1266E87A642CDA69A762 /* GeminiInlineDataImageScanner.swift */; };
@@ -489,6 +496,7 @@
 		5FAA1266E87A642CDA69A762 /* GeminiInlineDataImageScanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Utilities/GeminiInlineDataImageScanner.swift; sourceTree = SOURCE_ROOT; };
 		602CE18FB970A465454E6CF7 /* ClaudeProbeProject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClaudeProbeProject.swift; sourceTree = "<group>"; };
 		60591BB6BB1078FB824B8C96 /* CursorTranscriptView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Views/CursorTranscriptView.swift; sourceTree = SOURCE_ROOT; };
+		B7D1A2000004000000000001 /* BuddyTranscriptView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Views/BuddyTranscriptView.swift; sourceTree = SOURCE_ROOT; };
 		6505213F3D72B128BB972BA3 /* OpenClawBase64ImageScanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Utilities/OpenClawBase64ImageScanner.swift; sourceTree = SOURCE_ROOT; };
 		653CDA3AC37DFF0D1C2C5530 /* OpenCodeBase64ImageScannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/OpenCodeBase64ImageScannerTests.swift; sourceTree = SOURCE_ROOT; };
 		654BD9FEF4DBAEA20EBC1254 /* SessionIndexingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/SessionIndexingEngine.swift; sourceTree = SOURCE_ROOT; };
@@ -670,6 +678,9 @@
 		DDD22D951F7235BCDCB7373C /* AgentImageScannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/AgentImageScannerTests.swift; sourceTree = SOURCE_ROOT; };
 		DE3233D9D6CE429AB0173B04 /* CodexVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodexVersion.swift; path = AgentSessions/Resume/CodexVersion.swift; sourceTree = SOURCE_ROOT; };
 		DEC5DFBBBA1745F69422B117 /* DroidSessionParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/DroidSessionParserTests.swift; sourceTree = SOURCE_ROOT; };
+		B0000BUDY0A000100000001 /* BuddySessionParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/BuddySessionParserTests.swift; sourceTree = SOURCE_ROOT; };
+		B0000BUDY0A000100000002 /* BuddySessionDiscoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/BuddySessionDiscoveryTests.swift; sourceTree = SOURCE_ROOT; };
+		B0000BUDY0A000100000003 /* SearchCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/SearchCoordinatorTests.swift; sourceTree = SOURCE_ROOT; };
 		DF1EEA498EA54B428BC1AEA8 /* TranscriptCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptCache.swift; sourceTree = "<group>"; };
 		DF308FD04A790E21685E9FFD /* AgentCockpitHUDView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Views/AgentCockpitHUDView.swift; sourceTree = SOURCE_ROOT; };
 		E17FB1E129787D35D02F800D /* SearchSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Search/SearchSessionStore.swift; sourceTree = SOURCE_ROOT; };
@@ -690,6 +701,9 @@
 		EC634024CF768951D08698DC /* ClaudeUsageSnapshotStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/ClaudeOAuth/ClaudeUsageSnapshotStoreTests.swift; sourceTree = SOURCE_ROOT; };
 		EE51E91DDB45FF63A7579B6B /* ImageBrowserIndexCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Utilities/ImageBrowserIndexCache.swift; sourceTree = SOURCE_ROOT; };
 		EE556B1D5555A64D3FE9C459 /* CursorSessionIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/CursorSessionIndexer.swift; sourceTree = SOURCE_ROOT; };
+		B7D1A2000001000000000001 /* BuddySessionDiscovery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/BuddySessionDiscovery.swift; sourceTree = SOURCE_ROOT; };
+		B7D1A2000002000000000001 /* BuddySessionParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/BuddySessionParser.swift; sourceTree = SOURCE_ROOT; };
+		B7D1A2000003000000000001 /* BuddySessionIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/BuddySessionIndexer.swift; sourceTree = SOURCE_ROOT; };
 		EF2A3071BF27FDFC2D3389F3 /* AgentTerminalLauncher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Resume/AgentTerminalLauncher.swift; sourceTree = SOURCE_ROOT; };
 		F0FEAC403FCBFFD9BC241618 /* TranscriptGoldenFixtureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/TranscriptGoldenFixtureTests.swift; sourceTree = SOURCE_ROOT; };
 		F14273196C77AAA12FFDF3CE /* PreferencesView+General.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PreferencesView+General.swift"; path = "AgentSessions/Views/Preferences/PreferencesView+General.swift"; sourceTree = SOURCE_ROOT; };
@@ -1171,6 +1185,9 @@
 				DCAF2FBE83AB906E7AE27B14 /* ClaudeProbeProjectTests.swift */,
 				BC926C8029B5DCC347228C98 /* OnboardingCoordinatorTests.swift */,
 				DEC5DFBBBA1745F69422B117 /* DroidSessionParserTests.swift */,
+				B0000BUDY0A000100000001 /* BuddySessionParserTests.swift */,
+				B0000BUDY0A000100000002 /* BuddySessionDiscoveryTests.swift */,
+				B0000BUDY0A000100000003 /* SearchCoordinatorTests.swift */,
 				22E2B6C946DA8195F448959F /* FixturePaths.swift */,
 				C311CBC276711A2955D27C8E /* Stage0GoldenFixturesTests.swift */,
 				812D088A294DD367D06A8842 /* Stage0PerfHarnessTests.swift */,
@@ -1289,6 +1306,9 @@
 				244A406366EFEFF96A75B5DC /* CursorSessionDiscovery.swift */,
 				F907EDC5569C03CA84AC9963 /* CursorSessionParser.swift */,
 				EE556B1D5555A64D3FE9C459 /* CursorSessionIndexer.swift */,
+				B7D1A2000001000000000001 /* BuddySessionDiscovery.swift */,
+				B7D1A2000002000000000001 /* BuddySessionParser.swift */,
+				B7D1A2000003000000000001 /* BuddySessionIndexer.swift */,
 				3461C92597A6EC663D5D67EB /* HermesSessionDiscovery.swift */,
 				DC465AC4F3A51868CBF81044 /* HermesSessionParser.swift */,
 				30A71A6F3D66468A840DCEEE /* HermesSessionIndexer.swift */,
@@ -1359,6 +1379,7 @@
 				818D69C24F0559B1CFE37700 /* AgentCockpitHUDWindow.swift */,
 				688EDBBB7C4F356E51BF00B5 /* ClaudeTranscriptView.swift */,
 				60591BB6BB1078FB824B8C96 /* CursorTranscriptView.swift */,
+				B7D1A2000004000000000001 /* BuddyTranscriptView.swift */,
 				A87D9748A4FB1DC0944131E2 /* HermesTranscriptView.swift */,
 			);
 			path = Views;
@@ -2060,8 +2081,12 @@
 				7FB7424C6E9E83DD27243857 /* CursorSessionDiscovery.swift in Sources */,
 				C175836A2966A91207158754 /* CursorSessionParser.swift in Sources */,
 				EC762372C84091AFA2F77ECD /* CursorSessionIndexer.swift in Sources */,
+				B7D1A1000001000000000001 /* BuddySessionDiscovery.swift in Sources */,
+				B7D1A1000002000000000001 /* BuddySessionParser.swift in Sources */,
+				B7D1A1000003000000000001 /* BuddySessionIndexer.swift in Sources */,
 				9C1C91D57A76756AB7386E12 /* PreferencesView+Cursor.swift in Sources */,
 				867937185092A7641F1E1508 /* CursorTranscriptView.swift in Sources */,
+				B7D1A1000004000000000001 /* BuddyTranscriptView.swift in Sources */,
 				C6CE5E7F605CB2847D0B5CB3 /* CursorResumeTypes.swift in Sources */,
 				880E13C9200AB2F4EAC3FC53 /* CursorResumeCommandBuilder.swift in Sources */,
 				C29AFA5FF65A0EFD38A6B4DA /* CursorResumeCoordinator.swift in Sources */,
@@ -2100,6 +2125,9 @@
 				0B8F72366814B2724C5536B3 /* ClaudeProbeProject.swift in Sources */,
 				004565A06D339C3DF6552A18 /* OnboardingCoordinatorTests.swift in Sources */,
 				6829C28DA0E1BEE5984B8599 /* DroidSessionParserTests.swift in Sources */,
+				B0000BUDY0B000100000001 /* BuddySessionParserTests.swift in Sources */,
+				B0000BUDY0B000100000002 /* BuddySessionDiscoveryTests.swift in Sources */,
+				B0000BUDY0B000100000003 /* SearchCoordinatorTests.swift in Sources */,
 				79F61D0D12836CDD2A0CD265 /* FixturePaths.swift in Sources */,
 				9A33A0B24844EAD390958FAF /* Stage0GoldenFixturesTests.swift in Sources */,
 				1B537F76060E9F6BAE9BBF7E /* Stage0PerfHarnessTests.swift in Sources */,

--- a/AgentSessions/AgentSessionsApp.swift
+++ b/AgentSessions/AgentSessionsApp.swift
@@ -178,6 +178,8 @@ struct AgentSessionsApp: App {
     @StateObject private var droidIndexer = DroidSessionIndexer()
     @StateObject private var openclawIndexer = OpenClawSessionIndexer()
     @StateObject private var cursorIndexer = CursorSessionIndexer()
+    @StateObject private var codebuddyIndexer = BuddySessionIndexer(productSessionSource: .codebuddy)
+    @StateObject private var workbuddyIndexer = BuddySessionIndexer(productSessionSource: .workbuddy)
     @StateObject private var updaterController = UpdaterController()
     @StateObject private var onboardingCoordinator = OnboardingCoordinator()
     @StateObject private var unifiedIndexerHolder = _UnifiedHolder()
@@ -253,7 +255,9 @@ struct AgentSessionsApp: App {
                 copilotIndexer: copilotIndexer,
                 droidIndexer: droidIndexer,
                 openclawIndexer: openclawIndexer,
-                cursorIndexer: cursorIndexer
+                cursorIndexer: cursorIndexer,
+                codebuddyIndexer: codebuddyIndexer,
+                workbuddyIndexer: workbuddyIndexer
             )
             configuredUnifiedWindow(unified: unified)
         }
@@ -273,6 +277,8 @@ struct AgentSessionsApp: App {
             droidIndexer: droidIndexer,
             openclawIndexer: openclawIndexer,
             cursorIndexer: cursorIndexer,
+            codebuddyIndexer: codebuddyIndexer,
+            workbuddyIndexer: workbuddyIndexer,
             analyticsReady: analyticsReady,
             analyticsPhase: analyticsPhase,
             analyticsIsStale: analyticsStale,
@@ -348,6 +354,8 @@ struct AgentSessionsApp: App {
                     droidIndexer: droidIndexer,
                     openclawIndexer: openclawIndexer,
                     cursorIndexer: cursorIndexer,
+                    codebuddyIndexer: codebuddyIndexer,
+                    workbuddyIndexer: workbuddyIndexer,
                     codexUsageModel: codexUsageModel,
                     claudeUsageModel: claudeUsageModel
                 )
@@ -429,7 +437,9 @@ struct AgentSessionsApp: App {
                         copilotIndexer: copilotIndexer,
                         droidIndexer: droidIndexer,
                         openclawIndexer: openclawIndexer,
-                        cursorIndexer: cursorIndexer
+                        cursorIndexer: cursorIndexer,
+                        codebuddyIndexer: codebuddyIndexer,
+                        workbuddyIndexer: workbuddyIndexer
                     )
                 )
                 .environmentObject(archiveManager)
@@ -480,7 +490,9 @@ final class _UnifiedHolder: ObservableObject {
                      copilotIndexer: CopilotSessionIndexer,
                      droidIndexer: DroidSessionIndexer,
                      openclawIndexer: OpenClawSessionIndexer,
-                     cursorIndexer: CursorSessionIndexer) -> UnifiedSessionIndexer {
+                     cursorIndexer: CursorSessionIndexer,
+                     codebuddyIndexer: BuddySessionIndexer,
+                     workbuddyIndexer: BuddySessionIndexer) -> UnifiedSessionIndexer {
         if let u = unified { return u }
         let u = UnifiedSessionIndexer(codexIndexer: codexIndexer,
                                       claudeIndexer: claudeIndexer,
@@ -490,7 +502,9 @@ final class _UnifiedHolder: ObservableObject {
                                       copilotIndexer: copilotIndexer,
                                       droidIndexer: droidIndexer,
                                       openclawIndexer: openclawIndexer,
-                                      cursorIndexer: cursorIndexer)
+                                      cursorIndexer: cursorIndexer,
+                                      codebuddyIndexer: codebuddyIndexer,
+                                      workbuddyIndexer: workbuddyIndexer)
         unified = u
         return u
     }
@@ -573,7 +587,9 @@ extension AgentSessionsApp {
             copilotIndexer: copilotIndexer,
             droidIndexer: droidIndexer,
             openclawIndexer: openclawIndexer,
-            cursorIndexer: cursorIndexer
+            cursorIndexer: cursorIndexer,
+            codebuddyIndexer: codebuddyIndexer,
+            workbuddyIndexer: workbuddyIndexer
         )
     }
 
@@ -1057,6 +1073,8 @@ final class OnboardingWindowPresenter: NSObject, NSWindowDelegate {
         droidIndexer: DroidSessionIndexer,
         openclawIndexer: OpenClawSessionIndexer,
         cursorIndexer: CursorSessionIndexer,
+        codebuddyIndexer: BuddySessionIndexer,
+        workbuddyIndexer: BuddySessionIndexer,
         codexUsageModel: CodexUsageModel,
         claudeUsageModel: ClaudeUsageModel
     ) {
@@ -1073,6 +1091,8 @@ final class OnboardingWindowPresenter: NSObject, NSWindowDelegate {
             droidIndexer: droidIndexer,
             openclawIndexer: openclawIndexer,
             cursorIndexer: cursorIndexer,
+            codebuddyIndexer: codebuddyIndexer,
+            workbuddyIndexer: workbuddyIndexer,
             codexUsageModel: codexUsageModel,
             claudeUsageModel: claudeUsageModel
         )
@@ -1164,6 +1184,8 @@ private struct OnboardingWindowState {
     let droidIndexer: DroidSessionIndexer
     let openclawIndexer: OpenClawSessionIndexer
     let cursorIndexer: CursorSessionIndexer
+    let codebuddyIndexer: BuddySessionIndexer
+    let workbuddyIndexer: BuddySessionIndexer
     let codexUsageModel: CodexUsageModel
     let claudeUsageModel: ClaudeUsageModel
 }
@@ -1185,6 +1207,8 @@ private struct OnboardingWindowRoot: View {
             droidIndexer: state.droidIndexer,
             openclawIndexer: state.openclawIndexer,
             cursorIndexer: state.cursorIndexer,
+            codebuddyIndexer: state.codebuddyIndexer,
+            workbuddyIndexer: state.workbuddyIndexer,
             codexUsageModel: state.codexUsageModel,
             claudeUsageModel: state.claudeUsageModel
         )

--- a/AgentSessions/Analytics/Utilities/AnalyticsColors.swift
+++ b/AgentSessions/Analytics/Utilities/AnalyticsColors.swift
@@ -24,6 +24,10 @@ extension Color {
     static let agentOpenClaw: Color = TranscriptColorSystem.agentBrandAccent(source: .openclaw)
     /// Cursor brand color
     static let agentCursor: Color = TranscriptColorSystem.agentBrandAccent(source: .cursor)
+    /// CodeBuddy brand color
+    static let agentCodeBuddy: Color = TranscriptColorSystem.agentBrandAccent(source: .codebuddy)
+    /// WorkBuddy brand color
+    static let agentWorkBuddy: Color = TranscriptColorSystem.agentBrandAccent(source: .workbuddy)
 
     // MARK: - Monochrome Support
 
@@ -37,6 +41,8 @@ extension Color {
     static let agentDroidGray = Color(white: 0.8)
     static let agentOpenClawGray = Color(white: 0.85)
     static let agentCursorGray = Color(white: 0.9)
+    static let agentCodeBuddyGray = Color(white: 0.56)
+    static let agentWorkBuddyGray = Color(white: 0.62)
 
     /// Get the brand color for a given session source
     static func agentColor(for source: SessionSource) -> Color {
@@ -50,6 +56,8 @@ extension Color {
         case .droid: return .agentDroid
         case .openclaw: return .agentOpenClaw
         case .cursor: return .agentCursor
+        case .codebuddy: return .agentCodeBuddy
+        case .workbuddy: return .agentWorkBuddy
         }
     }
 
@@ -66,6 +74,8 @@ extension Color {
             case .droid: return .agentDroidGray
             case .openclaw: return .agentOpenClawGray
             case .cursor: return .agentCursorGray
+            case .codebuddy: return .agentCodeBuddyGray
+            case .workbuddy: return .agentWorkBuddyGray
             }
         } else {
             return agentColor(for: source)
@@ -89,6 +99,10 @@ extension Color {
             return .agentDroid
         } else if lower.contains("openclaw") || lower.contains("clawdbot") {
             return .agentOpenClaw
+        } else if lower.contains("codebuddy") {
+            return .agentCodeBuddy
+        } else if lower.contains("workbuddy") {
+            return .agentWorkBuddy
         } else {
             return .accentColor
         }
@@ -112,6 +126,10 @@ extension Color {
                 return .agentDroidGray
             } else if lower.contains("openclaw") || lower.contains("clawdbot") {
                 return .agentOpenClawGray
+            } else if lower.contains("codebuddy") {
+                return .agentCodeBuddyGray
+            } else if lower.contains("workbuddy") {
+                return .agentWorkBuddyGray
             } else {
                 return .secondary
             }

--- a/AgentSessions/Model/Session.swift
+++ b/AgentSessions/Model/Session.swift
@@ -423,6 +423,15 @@ public struct Session: Identifiable, Equatable, Codable, Sendable {
                 return true
             }
             return !meaningfulUser
+        case .codebuddy, .workbuddy:
+            if events.contains(where: { $0.kind == .assistant }) { return false }
+            if events.contains(where: { $0.kind == .tool_call || $0.kind == .tool_result }) { return false }
+            let meaningfulUser = events.contains { e in
+                guard e.kind == .user else { return false }
+                guard let raw = e.text?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return false }
+                return !looksLikeAgentsPreamble(raw)
+            }
+            return !meaningfulUser
         default:
             return false
         }

--- a/AgentSessions/Model/SessionEvent.swift
+++ b/AgentSessions/Model/SessionEvent.swift
@@ -30,13 +30,15 @@ extension SessionEventKind {
         if let t = type?.lowercased() {
             switch t {
             case "tool_call", "tool-call", "toolcall", "tool_use", "tool-use", "function_call", "web_search_call", "custom_tool_call": return .tool_call
-            case "tool_result", "tool-result", "toolresult", "function_result", "function_call_output", "web_search_call_output", "custom_tool_call_output": return .tool_result
+            case "tool_result", "tool-result", "toolresult", "function_result", "function_call_output", "function_call_result", "web_search_call_output", "custom_tool_call_output": return .tool_result
             case "error", "err": return .error
             case "meta",
                  "system",
                  "summary",
                  "file-history-snapshot",
                  "queue-operation",
+                 "reasoning",
+                 "topic",
                  "assistant.turn_start",
                  "assistant.turn_end",
                  "session.truncation",

--- a/AgentSessions/Model/SessionSource.swift
+++ b/AgentSessions/Model/SessionSource.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Identifies the source/type of a session (Codex CLI vs Claude Code)
-public enum SessionSource: String, Codable, CaseIterable, Sendable {
+public enum SessionSource: String, CaseIterable, Sendable {
     case codex = "codex"
     case claude = "claude"
     case gemini = "gemini"
@@ -11,6 +11,10 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
     case droid = "droid"
     case openclaw = "openclaw"
     case cursor = "cursor"
+    /// CodeBuddy CLI JSONL transcripts under `~/.codebuddy/projects/...`.
+    case codebuddy = "codebuddy"
+    /// WorkBuddy IDE JSONL transcripts under `~/.workbuddy/projects/...`.
+    case workbuddy = "workbuddy"
 
     public var displayName: String {
         switch self {
@@ -23,6 +27,8 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
         case .droid: return "Droid"
         case .openclaw: return "OpenClaw"
         case .cursor: return "Cursor"
+        case .codebuddy: return "CodeBuddy"
+        case .workbuddy: return "WorkBuddy"
         }
     }
 
@@ -37,6 +43,7 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
         case .droid: return "d.circle"
         case .openclaw: return "pawprint"
         case .cursor: return "cursorarrow.rays"
+        case .codebuddy, .workbuddy: return "bubble.left.and.bubble.right"
         }
     }
 
@@ -50,6 +57,7 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
         case .droid:            return "3.0"
         case .openclaw:         return "3.1"
         case .cursor:           return "3.2"
+        case .codebuddy, .workbuddy: return "3.7"
         }
     }
 
@@ -64,6 +72,28 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
         case .droid:    return "View your Droid agent sessions"
         case .openclaw: return "Explore your OpenClaw conversations"
         case .cursor:   return "Import and search your Cursor AI sessions"
+        case .codebuddy: return "Browse CodeBuddy CLI project transcripts"
+        case .workbuddy: return "Browse WorkBuddy IDE project transcripts"
         }
+    }
+}
+
+extension SessionSource: Codable {
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        let raw = try c.decode(String.self)
+        if raw == "buddy" {
+            self = .codebuddy
+            return
+        }
+        guard let v = SessionSource(rawValue: raw) else {
+            throw DecodingError.dataCorruptedError(in: c, debugDescription: "Unknown SessionSource \(raw)")
+        }
+        self = v
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        try c.encode(rawValue)
     }
 }

--- a/AgentSessions/Onboarding/Views/OnboardingSheetView.swift
+++ b/AgentSessions/Onboarding/Views/OnboardingSheetView.swift
@@ -13,6 +13,8 @@ struct OnboardingSheetView: View {
     let droidIndexer: DroidSessionIndexer
     let openclawIndexer: OpenClawSessionIndexer
     let cursorIndexer: CursorSessionIndexer
+    let codebuddyIndexer: BuddySessionIndexer
+    let workbuddyIndexer: BuddySessionIndexer
     @ObservedObject var codexUsageModel: CodexUsageModel
     @ObservedObject var claudeUsageModel: ClaudeUsageModel
 
@@ -28,6 +30,8 @@ struct OnboardingSheetView: View {
     @AppStorage(PreferencesKey.Agents.droidEnabled) private var droidAgentEnabled: Bool = true
     @AppStorage(PreferencesKey.Agents.openClawEnabled) private var openClawAgentEnabled: Bool = false
     @AppStorage(PreferencesKey.Agents.cursorEnabled) private var cursorAgentEnabled: Bool = true
+    @AppStorage(PreferencesKey.Agents.codebuddyEnabled) private var codebuddyAgentEnabled: Bool = true
+    @AppStorage(PreferencesKey.Agents.workbuddyEnabled) private var workbuddyAgentEnabled: Bool = true
 
     @AppStorage(PreferencesKey.codexUsageEnabled) private var codexUsageEnabled: Bool = false
     @AppStorage(PreferencesKey.claudeUsageEnabled) private var claudeUsageEnabled: Bool = false
@@ -135,6 +139,8 @@ struct OnboardingSheetView: View {
         .onReceive(droidIndexer.$allSessions) { _ in handleSessionDataUpdate() }
         .onReceive(openclawIndexer.$allSessions) { _ in handleSessionDataUpdate() }
         .onReceive(cursorIndexer.$allSessions) { _ in handleSessionDataUpdate() }
+        .onReceive(codebuddyIndexer.$allSessions) { _ in handleSessionDataUpdate() }
+        .onReceive(workbuddyIndexer.$allSessions) { _ in handleSessionDataUpdate() }
         .onChange(of: hideZeroMessageSessionsPref) { _, _ in handleSessionDataUpdate() }
         .onChange(of: hideLowMessageSessionsPref) { _, _ in handleSessionDataUpdate() }
         .onChange(of: showHousekeepingSessionsPref) { _, _ in handleSessionDataUpdate() }
@@ -669,6 +675,16 @@ struct OnboardingSheetView: View {
                 get: { cursorAgentEnabled },
                 set: { _ = AgentEnablement.setEnabled(.cursor, enabled: $0) }
             )
+        case .codebuddy:
+            return Binding(
+                get: { codebuddyAgentEnabled },
+                set: { _ = AgentEnablement.setEnabled(.codebuddy, enabled: $0) }
+            )
+        case .workbuddy:
+            return Binding(
+                get: { workbuddyAgentEnabled },
+                set: { _ = AgentEnablement.setEnabled(.workbuddy, enabled: $0) }
+            )
         }
     }
 
@@ -745,6 +761,8 @@ struct OnboardingSheetView: View {
         case .droid: return droidIndexer.allSessions
         case .openclaw: return openclawIndexer.allSessions
         case .cursor: return cursorIndexer.allSessions
+        case .codebuddy: return codebuddyIndexer.allSessions
+        case .workbuddy: return workbuddyIndexer.allSessions
         }
     }
 
@@ -759,6 +777,8 @@ struct OnboardingSheetView: View {
         case .droid: return droidAgentEnabled
         case .openclaw: return openClawAgentEnabled
         case .cursor: return cursorAgentEnabled
+        case .codebuddy: return codebuddyAgentEnabled
+        case .workbuddy: return workbuddyAgentEnabled
         }
     }
 
@@ -808,6 +828,8 @@ struct OnboardingSheetView: View {
             + droidIndexer.allSessions
             + openclawIndexer.allSessions
             + cursorIndexer.allSessions
+            + codebuddyIndexer.allSessions
+            + workbuddyIndexer.allSessions
         return WeeklyActivityDay.build(from: sessions, palette: palette)
     }
 
@@ -839,7 +861,7 @@ struct OnboardingSheetView: View {
         // Tool-call-only filter (strict)
         if hasCommandsOnlyPref {
             switch session.source {
-            case .codex, .opencode, .hermes, .copilot, .droid, .openclaw, .cursor:
+            case .codex, .opencode, .hermes, .copilot, .droid, .openclaw, .cursor, .codebuddy, .workbuddy:
                 if !session.events.isEmpty {
                     if !session.events.contains(where: { $0.kind == .tool_call }) { return false }
                 } else {
@@ -1101,6 +1123,8 @@ private struct AgentBadge: View {
         case .droid: return "D"
         case .openclaw: return "CL"
         case .cursor: return "CR"
+        case .codebuddy: return "CB"
+        case .workbuddy: return "WB"
         }
     }
 }
@@ -2162,6 +2186,10 @@ private struct OnboardingPalette {
             return Color(red: 0.95, green: 0.55, blue: 0.18)
         case .cursor:
             return Color(red: 0.20, green: 0.60, blue: 0.70)
+        case .codebuddy:
+            return Color.agentCodeBuddy
+        case .workbuddy:
+            return Color.agentWorkBuddy
         }
     }
 }

--- a/AgentSessions/Search/SearchCoordinator.swift
+++ b/AgentSessions/Search/SearchCoordinator.swift
@@ -96,6 +96,10 @@ final class SearchCoordinator: ObservableObject, @unchecked Sendable {
         return UserDefaults.standard.bool(forKey: PreferencesKey.Advanced.enableRecentToolIOIndex)
     }
 
+    static func ftsEligibleSources(from allowed: Set<SessionSource>) -> Set<SessionSource> {
+        allowed.filter { $0 != .cursor && $0 != .codebuddy && $0 != .workbuddy }
+    }
+
     func cancel() {
         cancel(clearResults: true)
     }
@@ -173,6 +177,8 @@ final class SearchCoordinator: ObservableObject, @unchecked Sendable {
                includeDroid: Bool,
                includeOpenClaw: Bool,
                includeCursor: Bool,
+               includeCodebuddy: Bool,
+               includeWorkbuddy: Bool,
                enableDeepScan: Bool,
                all: [Session]) {
         // Cancel any in-flight search
@@ -194,6 +200,8 @@ final class SearchCoordinator: ObservableObject, @unchecked Sendable {
             if includeDroid { set.insert(.droid) }
             if includeOpenClaw { set.insert(.openclaw) }
             if includeCursor { set.insert(.cursor) }
+            if includeCodebuddy { set.insert(.codebuddy) }
+            if includeWorkbuddy { set.insert(.workbuddy) }
             return set
         }()
         
@@ -208,9 +216,21 @@ final class SearchCoordinator: ObservableObject, @unchecked Sendable {
 
         // Phase 0: fast path via SQLite FTS if available.
         if FeatureFlags.enableFTSSearch, let db = db {
-            // Cursor sessions are not indexed in the FTS database — exclude from FTS queries
+            // Cursor/Buddy sessions are not indexed in the FTS database — exclude from FTS queries
             // so they fall through to the unindexed/legacy transcript-cache search path.
-            let ftsAllowed = allowed.filter { $0 != .cursor }
+            let ftsAllowed = Self.ftsEligibleSources(from: allowed)
+            if ftsAllowed.isEmpty {
+                Task { [weak self] in
+                    guard let self else { return }
+                    await self.startLegacySearch(runID: newRunID,
+                                                 query: query,
+                                                 filters: filters,
+                                                 allowed: allowed,
+                                                 all: all,
+                                                 allowDeepScan: enableDeepScan)
+                }
+                return
+            }
             let allowedRaw = ftsAllowed.map { $0.rawValue }
             let parsed = FilterEngine.parseOperators(filters.query)
             let freeText = parsed.freeText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -332,7 +352,7 @@ final class SearchCoordinator: ObservableObject, @unchecked Sendable {
                     let unindexedCandidates = candidates.filter {
                         !indexedIDs.contains($0.id)
                             && !seen.contains($0.id)
-                            && (enableDeepScan || $0.source == .cursor || Self.sizeBytes(for: $0) < smallSearchThreshold)
+                            && (enableDeepScan || Self.ftsEligibleSources(from: [$0.source]).isEmpty || Self.sizeBytes(for: $0) < smallSearchThreshold)
                     }
                     let deepCandidates = deepEnabled
                         ? candidates.filter { indexedIDs.contains($0.id) && !seen.contains($0.id) && Self.shouldDeepScan(session: $0) }

--- a/AgentSessions/Services/AgentEnablement.swift
+++ b/AgentSessions/Services/AgentEnablement.swift
@@ -1,6 +1,36 @@
 import Foundation
 
 enum AgentEnablement {
+    private static let buddySplitMigrationDefaultsKey = "DidMigrateBuddyAgentSplit_v1"
+
+    /// Copies legacy `AgentEnabledBuddy` / `IncludeBuddySessions` into per-product keys once.
+    static func migrateBuddyAgentSplitIfNeeded(defaults: UserDefaults = .standard) {
+        guard !defaults.bool(forKey: buddySplitMigrationDefaultsKey) else { return }
+        defer { defaults.set(true, forKey: buddySplitMigrationDefaultsKey) }
+
+        if defaults.object(forKey: PreferencesKey.Agents.codebuddyEnabled) == nil,
+           defaults.object(forKey: PreferencesKey.Agents.workbuddyEnabled) == nil,
+           let legacy = defaults.object(forKey: PreferencesKey.Agents.buddyEnabled) as? Bool {
+            defaults.set(legacy, forKey: PreferencesKey.Agents.codebuddyEnabled)
+            defaults.set(legacy, forKey: PreferencesKey.Agents.workbuddyEnabled)
+        }
+
+        if defaults.object(forKey: "IncludeCodebuddySessions") == nil,
+           defaults.object(forKey: "IncludeWorkbuddySessions") == nil {
+            let incLegacy = defaults.object(forKey: "IncludeBuddySessions") as? Bool ?? true
+            defaults.set(incLegacy, forKey: "IncludeCodebuddySessions")
+            defaults.set(incLegacy, forKey: "IncludeWorkbuddySessions")
+        }
+
+        if var known = defaults.stringArray(forKey: PreferencesKey.Agents.knownAvailableProviders),
+           let idx = known.firstIndex(of: "buddy") {
+            known.remove(at: idx)
+            if !known.contains(SessionSource.codebuddy.rawValue) { known.append(SessionSource.codebuddy.rawValue) }
+            if !known.contains(SessionSource.workbuddy.rawValue) { known.append(SessionSource.workbuddy.rawValue) }
+            defaults.set(known, forKey: PreferencesKey.Agents.knownAvailableProviders)
+        }
+    }
+
     enum StoredAvailabilityStatus {
         case installed
         case configured
@@ -58,6 +88,10 @@ enum AgentEnablement {
             return isAvailable(.openclaw, defaults: defaults)
         case .cursor:
             return isAvailable(.cursor, defaults: defaults)
+        case .codebuddy:
+            return isAvailable(.codebuddy, defaults: defaults)
+        case .workbuddy:
+            return isAvailable(.workbuddy, defaults: defaults)
         default:
             return true
         }
@@ -74,6 +108,8 @@ enum AgentEnablement {
         case .droid:    return PreferencesKey.Agents.droidEnabled
         case .openclaw: return PreferencesKey.Agents.openClawEnabled
         case .cursor:   return PreferencesKey.Agents.cursorEnabled
+        case .codebuddy: return PreferencesKey.Agents.codebuddyEnabled
+        case .workbuddy: return PreferencesKey.Agents.workbuddyEnabled
         }
     }
 
@@ -153,6 +189,7 @@ enum AgentEnablement {
 
     static func seedIfNeeded(defaults: UserDefaults = .standard) {
         guard !AppRuntime.isHostedByTooling else { return }
+        migrateBuddyAgentSplitIfNeeded(defaults: defaults)
         if defaults.bool(forKey: PreferencesKey.Agents.didSeedEnabledAgents) { return }
 
         // Migration: if the old "show toolbar filter" keys exist, treat them as the initial enabled set.
@@ -177,6 +214,8 @@ enum AgentEnablement {
             setEnabledInternal(.droid, enabled: isAvailable(.droid, defaults: defaults), defaults: defaults)
             setEnabledInternal(.openclaw, enabled: isAvailable(.openclaw, defaults: defaults), defaults: defaults)
             setEnabledInternal(.cursor, enabled: isAvailable(.cursor, defaults: defaults), defaults: defaults)
+            setEnabledInternal(.codebuddy, enabled: isAvailable(.codebuddy, defaults: defaults), defaults: defaults)
+            setEnabledInternal(.workbuddy, enabled: isAvailable(.workbuddy, defaults: defaults), defaults: defaults)
         } else {
             // Cold start: avoid spawning the user's login shell (can be slow with heavy rc files).
             // Prefer filesystem availability checks and fall back to a fast PATH/common-locations probe.
@@ -189,6 +228,8 @@ enum AgentEnablement {
             let droid = isAvailable(.droid, defaults: defaults)
             let openclaw = isAvailable(.openclaw, defaults: defaults)
             let cursor = isAvailable(.cursor, defaults: defaults)
+            let codebuddy = isAvailable(.codebuddy, defaults: defaults)
+            let workbuddy = isAvailable(.workbuddy, defaults: defaults)
 
             setEnabledInternal(.codex, enabled: codex, defaults: defaults)
             setEnabledInternal(.claude, enabled: claude, defaults: defaults)
@@ -199,6 +240,8 @@ enum AgentEnablement {
             setEnabledInternal(.droid, enabled: droid, defaults: defaults)
             setEnabledInternal(.openclaw, enabled: openclaw, defaults: defaults)
             setEnabledInternal(.cursor, enabled: cursor, defaults: defaults)
+            setEnabledInternal(.codebuddy, enabled: codebuddy, defaults: defaults)
+            setEnabledInternal(.workbuddy, enabled: workbuddy, defaults: defaults)
         }
 
         // Guarantee at least one enabled agent.
@@ -218,6 +261,32 @@ enum AgentEnablement {
         var isDir: ObjCBool = false
         let root: URL
         switch source {
+        case .codebuddy:
+            let c = defaults.string(forKey: PreferencesKey.Paths.buddyCodebuddyProjectsRootOverride) ?? ""
+            let disc = BuddySessionDiscovery(
+                codebuddyProjectsRoot: c.isEmpty ? nil : c,
+                workbuddyProjectsRoot: nil,
+                scanCodebuddy: true,
+                scanWorkbuddy: false
+            )
+            for u in disc.projectRoots() {
+                var dir: ObjCBool = false
+                if fm.fileExists(atPath: u.path, isDirectory: &dir), dir.boolValue { return true }
+            }
+            return binaryInstalled(for: .codebuddy)
+        case .workbuddy:
+            let w = defaults.string(forKey: PreferencesKey.Paths.buddyWorkbuddyProjectsRootOverride) ?? ""
+            let disc = BuddySessionDiscovery(
+                codebuddyProjectsRoot: nil,
+                workbuddyProjectsRoot: w.isEmpty ? nil : w,
+                scanCodebuddy: false,
+                scanWorkbuddy: true
+            )
+            for u in disc.projectRoots() {
+                var dir: ObjCBool = false
+                if fm.fileExists(atPath: u.path, isDirectory: &dir), dir.boolValue { return true }
+            }
+            return binaryInstalled(for: .workbuddy)
         case .codex:
             let custom = defaults.string(forKey: "SessionsRootOverride") ?? ""
             root = CodexSessionDiscovery(customRoot: custom.isEmpty ? nil : custom).sessionsRoot()
@@ -291,6 +360,10 @@ enum AgentEnablement {
             return binaryDetectedCached("openclaw") || binaryDetectedCached("clawdbot")
         case .cursor:
             return binaryDetectedCached("agent") || binaryDetectedCached("cursor") || binaryDetectedCached("cursor-agent")
+        case .codebuddy:
+            return binaryDetectedCached("codebuddy")
+        case .workbuddy:
+            return binaryDetectedCached("workbuddy")
         }
     }
 
@@ -341,6 +414,8 @@ enum AgentEnablement {
             return nil
         case .cursor:
             return defaults.object(forKey: PreferencesKey.cursorCLIAvailable) as? Bool
+        case .codebuddy, .workbuddy:
+            return nil
         }
     }
 

--- a/AgentSessions/Services/AgentUpdateService.swift
+++ b/AgentSessions/Services/AgentUpdateService.swift
@@ -394,6 +394,8 @@ private extension AgentUpdateService {
             )
         case .cursor:
             return nil
+        case .codebuddy, .workbuddy:
+            return nil
         }
     }
 

--- a/AgentSessions/Services/BuddySessionDiscovery.swift
+++ b/AgentSessions/Services/BuddySessionDiscovery.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Discovers CodeBuddy / WorkBuddy session JSONL files under each product's `projects/` tree.
+///
+/// Observed layouts (2026-04):
+/// - `~/.codebuddy/projects/<path-encoding>/<uuid>.jsonl` (+ optional `<uuid>/subagents/*.jsonl`)
+/// - `~/.workbuddy/projects/<path-encoding>/<session>.jsonl`
+///
+/// Tool artifact directories such as `tool-results/` are skipped — they are not conversation transcripts.
+final class BuddySessionDiscovery {
+    private let codebuddyProjectsOverride: String?
+    private let workbuddyProjectsOverride: String?
+    private let scanCodebuddy: Bool
+    private let scanWorkbuddy: Bool
+
+    /// - Parameters:
+    ///   - scanCodebuddy: When false, no CodeBuddy roots are scanned (used by the WorkBuddy-only indexer).
+    ///   - scanWorkbuddy: When false, no WorkBuddy roots are scanned (used by the CodeBuddy-only indexer).
+    init(
+        codebuddyProjectsRoot: String? = nil,
+        workbuddyProjectsRoot: String? = nil,
+        scanCodebuddy: Bool = true,
+        scanWorkbuddy: Bool = true
+    ) {
+        self.codebuddyProjectsOverride = codebuddyProjectsRoot
+        self.workbuddyProjectsOverride = workbuddyProjectsRoot
+        self.scanCodebuddy = scanCodebuddy
+        self.scanWorkbuddy = scanWorkbuddy
+    }
+
+    static func defaultCodebuddyProjectsRoot() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codebuddy/projects")
+    }
+
+    static func defaultWorkbuddyProjectsRoot() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".workbuddy/projects")
+    }
+
+    func projectRoots() -> [URL] {
+        var roots: [URL] = []
+        if scanCodebuddy {
+            if let o = codebuddyProjectsOverride, !o.isEmpty {
+                roots.append(URL(fileURLWithPath: o))
+            } else {
+                roots.append(Self.defaultCodebuddyProjectsRoot())
+            }
+        }
+        if scanWorkbuddy {
+            if let o = workbuddyProjectsOverride, !o.isEmpty {
+                roots.append(URL(fileURLWithPath: o))
+            } else {
+                roots.append(Self.defaultWorkbuddyProjectsRoot())
+            }
+        }
+        return roots
+    }
+
+    func discoverSessionFiles() -> [URL] {
+        let fm = FileManager.default
+        var found: [URL] = []
+        found.reserveCapacity(256)
+        for root in projectRoots() {
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: root.path, isDirectory: &isDir), isDir.boolValue else { continue }
+            guard let en = fm.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles]) else { continue }
+            for case let url as URL in en {
+                let path = url.path
+                if path.contains("/tool-results/") { continue }
+                let ext = url.pathExtension.lowercased()
+                guard ext == "jsonl" else { continue }
+                let rv = try? url.resourceValues(forKeys: [.isRegularFileKey])
+                guard rv?.isRegularFile == true else { continue }
+                found.append(url)
+            }
+        }
+        var seen = Set<String>()
+        var unique: [URL] = []
+        unique.reserveCapacity(found.count)
+        for u in found {
+            let key = u.resolvingSymlinksInPath().path
+            guard seen.insert(key).inserted else { continue }
+            unique.append(u)
+        }
+        return unique.sorted { Self.mtime($0) > Self.mtime($1) }
+    }
+
+    private static func mtime(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+    }
+}

--- a/AgentSessions/Services/BuddySessionIndexer.swift
+++ b/AgentSessions/Services/BuddySessionIndexer.swift
@@ -1,0 +1,300 @@
+import Foundation
+import Combine
+import SwiftUI
+
+/// Indexes JSONL transcripts for one Buddy product (CodeBuddy or WorkBuddy).
+final class BuddySessionIndexer: ObservableObject, @unchecked Sendable {
+    @Published private(set) var allSessions: [Session] = []
+    @Published private(set) var sessions: [Session] = []
+    @Published var isIndexing: Bool = false
+    @Published var isProcessingTranscripts: Bool = false
+    @Published var progressText: String = ""
+    @Published var filesProcessed: Int = 0
+    @Published var totalFiles: Int = 0
+    @Published var indexingError: String? = nil
+    @Published var hasEmptyDirectory: Bool = false
+    @Published var launchPhase: LaunchPhase = .idle
+
+    @Published var query: String = ""
+    @Published var queryDraft: String = ""
+    @Published var dateFrom: Date? = nil
+    @Published var dateTo: Date? = nil
+    @Published var selectedModel: String? = nil
+    @Published var selectedKinds: Set<SessionEventKind> = Set(SessionEventKind.allCases)
+    @Published var projectFilter: String? = nil
+    @Published var isLoadingSession: Bool = false
+    @Published var loadingSessionID: String? = nil
+
+    @Published var activeSearchUI: SessionIndexer.ActiveSearchUI = .none
+
+    private let transcriptCache = TranscriptCache()
+    internal var searchTranscriptCache: TranscriptCache { transcriptCache }
+
+    private let productSource: SessionSource
+    private var discovery: BuddySessionDiscovery
+    private var lastCodebuddyOverride: String = ""
+    private var lastWorkbuddyOverride: String = ""
+    private let progressThrottler = ProgressThrottler()
+    private var cancellables = Set<AnyCancellable>()
+    private var refreshToken = UUID()
+    private var reloadingSessionIDs: Set<String> = []
+    private let reloadLock = NSLock()
+    private var lastFullReloadFileStatsBySessionID: [String: SessionFileStat] = [:]
+
+    init(productSessionSource: SessionSource) {
+        precondition(productSessionSource == .codebuddy || productSessionSource == .workbuddy)
+        self.productSource = productSessionSource
+        let c = UserDefaults.standard.string(forKey: PreferencesKey.Paths.buddyCodebuddyProjectsRootOverride) ?? ""
+        let w = UserDefaults.standard.string(forKey: PreferencesKey.Paths.buddyWorkbuddyProjectsRootOverride) ?? ""
+        self.lastCodebuddyOverride = c
+        self.lastWorkbuddyOverride = w
+        self.discovery = BuddySessionDiscovery(
+            codebuddyProjectsRoot: c.isEmpty ? nil : c,
+            workbuddyProjectsRoot: w.isEmpty ? nil : w,
+            scanCodebuddy: productSessionSource == .codebuddy,
+            scanWorkbuddy: productSessionSource == .workbuddy
+        )
+
+        let inputs = Publishers.CombineLatest4(
+            $query.removeDuplicates(),
+            $dateFrom.removeDuplicates(by: OptionalDateEquality.eq),
+            $dateTo.removeDuplicates(by: OptionalDateEquality.eq),
+            $selectedModel.removeDuplicates()
+        )
+        Publishers.CombineLatest3(inputs, $selectedKinds.removeDuplicates(), $allSessions)
+            .receive(on: FeatureFlags.lowerQoSForHeavyWork ? DispatchQueue.global(qos: .utility) : DispatchQueue.global(qos: .userInitiated))
+            .map { [weak self] input, kinds, all -> [Session] in
+                let (q, from, to, model) = input
+                let filters = Filters(query: q, dateFrom: from, dateTo: to, model: model, kinds: kinds, repoName: self?.projectFilter, pathContains: nil)
+                var results = FilterEngine.filterSessions(
+                    all,
+                    filters: filters,
+                    transcriptCache: self?.transcriptCache,
+                    allowTranscriptGeneration: !FeatureFlags.filterUsesCachedTranscriptOnly
+                )
+                let hideZero = UserDefaults.standard.object(forKey: "HideZeroMessageSessions") as? Bool ?? true
+                let hideLow = UserDefaults.standard.object(forKey: "HideLowMessageSessions") as? Bool ?? true
+                if hideZero { results = results.filter { $0.messageCount > 0 } }
+                if hideLow { results = results.filter { $0.messageCount == 0 || $0.messageCount > 2 } }
+                return results
+            }
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$sessions)
+    }
+
+    var canAccessRootDirectory: Bool {
+        discovery.projectRoots().contains { root in
+            var isDir: ObjCBool = false
+            return FileManager.default.fileExists(atPath: root.path, isDirectory: &isDir) && isDir.boolValue
+        }
+    }
+
+    func refresh(mode: IndexRefreshMode = .incremental,
+                 trigger: IndexRefreshTrigger = .manual,
+                 executionProfile: IndexRefreshExecutionProfile = .interactive) {
+        if !AgentEnablement.isEnabled(productSource) { return }
+
+        let c = UserDefaults.standard.string(forKey: PreferencesKey.Paths.buddyCodebuddyProjectsRootOverride) ?? ""
+        let w = UserDefaults.standard.string(forKey: PreferencesKey.Paths.buddyWorkbuddyProjectsRootOverride) ?? ""
+        if c != lastCodebuddyOverride || w != lastWorkbuddyOverride {
+            discovery = BuddySessionDiscovery(
+                codebuddyProjectsRoot: c.isEmpty ? nil : c,
+                workbuddyProjectsRoot: w.isEmpty ? nil : w,
+                scanCodebuddy: productSource == .codebuddy,
+                scanWorkbuddy: productSource == .workbuddy
+            )
+            lastCodebuddyOverride = c
+            lastWorkbuddyOverride = w
+        }
+
+        let token = UUID()
+        refreshToken = token
+        launchPhase = .hydrating
+        isIndexing = true
+        isProcessingTranscripts = false
+        progressText = "Scanning..."
+        filesProcessed = 0
+        totalFiles = 0
+        indexingError = nil
+        hasEmptyDirectory = false
+
+        let parseLightweight: (URL) -> Session? = { [productSource] url in
+            switch productSource {
+            case .codebuddy: return CodebuddySessionParser.parseFile(at: url)
+            case .workbuddy: return WorkbuddySessionParser.parseFile(at: url)
+            default: return nil
+            }
+        }
+
+        let requestedPriority: TaskPriority = executionProfile.deferNonCriticalWork ? .utility : .userInitiated
+        let prio: TaskPriority = FeatureFlags.lowerQoSForHeavyWork ? .utility : requestedPriority
+        Task.detached(priority: prio) { [weak self, token, executionProfile, parseLightweight] in
+            guard let self else { return }
+
+            let config = SessionIndexingEngine.ScanConfig(
+                source: self.productSource,
+                discoverFiles: {
+                    let files = self.discovery.discoverSessionFiles()
+                    LaunchProfiler.log("Buddy[\(self.productSource.rawValue)].refresh: file enumeration done (files=\(files.count))")
+                    return files
+                },
+                parseLightweight: parseLightweight,
+                shouldThrottleProgress: FeatureFlags.throttleIndexingUIUpdates,
+                throttler: self.progressThrottler,
+                shouldContinue: { self.refreshToken == token },
+                workerCount: executionProfile.workerCount,
+                sliceSize: executionProfile.sliceSize,
+                interSliceYieldNanoseconds: executionProfile.interSliceYieldNanoseconds,
+                onProgress: { processed, total in
+                    guard self.refreshToken == token else { return }
+                    self.totalFiles = total
+                    self.hasEmptyDirectory = (total == 0)
+                    self.filesProcessed = processed
+                    if processed > 0 {
+                        self.progressText = "Indexed \(processed)/\(total)"
+                    }
+                    if self.launchPhase == .hydrating {
+                        self.launchPhase = .scanning
+                    }
+                }
+            )
+
+            let result = await SessionIndexingEngine.hydrateOrScan(config: config)
+
+            await MainActor.run {
+                guard self.refreshToken == token else { return }
+                LaunchProfiler.log("Buddy[\(self.productSource.rawValue)].refresh: sessions merged (total=\(result.sessions.count))")
+                self.allSessions = result.sessions
+                self.isIndexing = false
+                if FeatureFlags.throttleIndexingUIUpdates {
+                    self.filesProcessed = self.totalFiles
+                    if self.totalFiles > 0 {
+                        self.progressText = "Indexed \(self.totalFiles)/\(self.totalFiles)"
+                    }
+                }
+                self.progressText = "Ready"
+                self.launchPhase = .ready
+            }
+        }
+    }
+
+    enum ReloadReason: String {
+        case selection
+        case focusedSessionMonitor
+        case manualRefresh
+    }
+
+    func reloadSession(id: String, force: Bool = false, reason: ReloadReason = .selection) {
+        reloadLock.lock()
+        if reloadingSessionIDs.contains(id) {
+            reloadLock.unlock()
+            return
+        }
+        reloadingSessionIDs.insert(id)
+        reloadLock.unlock()
+
+        let existingSnapshot: Session? = {
+            if Thread.isMainThread {
+                return self.allSessions.first(where: { $0.id == id })
+            }
+            var session: Session?
+            DispatchQueue.main.sync {
+                session = self.allSessions.first(where: { $0.id == id })
+            }
+            return session
+        }()
+
+        let bgQueue = FeatureFlags.lowerQoSForHeavyWork ? DispatchQueue.global(qos: .utility) : DispatchQueue.global(qos: .userInitiated)
+        bgQueue.async {
+            defer {
+                self.reloadLock.lock()
+                self.reloadingSessionIDs.remove(id)
+                self.reloadLock.unlock()
+            }
+
+            guard let existing = existingSnapshot,
+                  FileManager.default.fileExists(atPath: existing.filePath) else {
+                return
+            }
+
+            let hasLoadedEvents = !existing.events.isEmpty
+            if hasLoadedEvents && !force { return }
+
+            let url = URL(fileURLWithPath: existing.filePath)
+            let preParseStat = Self.fileStat(for: url)
+
+            let shouldSurfaceLoadingState = reason == .manualRefresh || !hasLoadedEvents
+            if shouldSurfaceLoadingState {
+                Task { @MainActor [weak self] in
+                    self?.isLoadingSession = true
+                    self?.loadingSessionID = id
+                }
+            }
+
+            let full: Session?
+            switch self.productSource {
+            case .codebuddy: full = CodebuddySessionParser.parseFileFull(at: url, forcedID: id)
+            case .workbuddy: full = WorkbuddySessionParser.parseFileFull(at: url, forcedID: id)
+            default: full = nil
+            }
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                defer {
+                    if shouldSurfaceLoadingState, self.loadingSessionID == id {
+                        self.isLoadingSession = false
+                        self.loadingSessionID = nil
+                    }
+                }
+
+                if let full, let idx = self.allSessions.firstIndex(where: { $0.id == id }) {
+                    let current = self.allSessions[idx]
+                    let merged = Session(
+                        id: full.id,
+                        source: full.source,
+                        startTime: full.startTime ?? current.startTime,
+                        endTime: full.endTime ?? current.endTime,
+                        model: full.model ?? current.model,
+                        filePath: full.filePath,
+                        fileSizeBytes: full.fileSizeBytes ?? current.fileSizeBytes,
+                        eventCount: max(current.eventCount, full.nonMetaCount),
+                        events: full.events,
+                        cwd: current.lightweightCwd ?? full.cwd,
+                        repoName: current.repoName ?? full.repoName,
+                        lightweightTitle: current.lightweightTitle ?? full.lightweightTitle,
+                        lightweightCommands: current.lightweightCommands,
+                        isHousekeeping: full.isHousekeeping,
+                        codexInternalSessionIDHint: full.codexInternalSessionIDHint ?? current.codexInternalSessionIDHint
+                    )
+                    self.allSessions[idx] = merged
+                    if let preParseStat {
+                        self.lastFullReloadFileStatsBySessionID[id] = preParseStat
+                    }
+                    let filters: TranscriptFilters = .current(showTimestamps: false, showMeta: false)
+                    let transcript = SessionTranscriptBuilder.buildPlainTerminalTranscript(session: merged, filters: filters, mode: .normal)
+                    self.transcriptCache.set(merged.id, transcript: transcript)
+                }
+            }
+        }
+    }
+
+    func updateSession(_ updated: Session) {
+        if let idx = allSessions.firstIndex(where: { $0.id == updated.id }) {
+            allSessions[idx] = updated
+        }
+        let filters: TranscriptFilters = .current(showTimestamps: false, showMeta: false)
+        let transcript = SessionTranscriptBuilder.buildPlainTerminalTranscript(session: updated, filters: filters, mode: .normal)
+        transcriptCache.set(updated.id, transcript: transcript)
+    }
+
+    private static func fileStat(for url: URL) -> SessionFileStat? {
+        guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
+              let modified = values.contentModificationDate else {
+            return nil
+        }
+        let size = Int64(values.fileSize ?? 0)
+        return SessionFileStat(mtime: Int64(modified.timeIntervalSince1970), size: size)
+    }
+}
+
+extension BuddySessionIndexer: SessionIndexerProtocol {}

--- a/AgentSessions/Services/BuddySessionParser.swift
+++ b/AgentSessions/Services/BuddySessionParser.swift
@@ -1,0 +1,422 @@
+import Foundation
+import CryptoKit
+
+/// Shared JSONL line parsing for CodeBuddy and WorkBuddy transcripts.
+///
+/// Each product has its own facade parser type so line schemas can diverge later while
+/// reusing timestamp extraction, content stringification, and `SessionEvent` mapping.
+enum BuddyJSONLTranscriptParsing {
+    private static let maxRawJSONFieldBytes = 8_192
+    private static let previewLineLimit = 120
+    private static let maxLightweightScanLines = 5_000
+
+    // MARK: - Lightweight
+
+    static func parseFile(at url: URL, source: SessionSource, forcedID: String? = nil) -> Session? {
+        assert(source == .codebuddy || source == .workbuddy)
+        let attrs = (try? FileManager.default.attributesOfItem(atPath: url.path)) ?? [:]
+        let size = (attrs[.size] as? NSNumber)?.intValue ?? -1
+        let mtime = (attrs[.modificationDate] as? Date) ?? Date()
+        let ctime = (attrs[.creationDate] as? Date) ?? mtime
+
+        let reader = JSONLReader(url: url)
+        var messageCount = 0
+        var toolCount = 0
+        var firstUser: String?
+        var idx = 0
+        var sessionHint: String?
+        var cwd: String?
+        var model: String?
+        var tmin: Date?
+        var tmax: Date?
+
+        do {
+            try reader.forEachLineWhile { rawLine in
+                idx += 1
+                guard idx <= maxLightweightScanLines else { return false }
+                if idx > previewLineLimit, messageCount > 0 { return false }
+                guard let data = rawLine.data(using: .utf8),
+                      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    return true
+                }
+                if sessionHint == nil, let sid = obj["sessionId"] as? String, !sid.isEmpty {
+                    sessionHint = sid
+                }
+                if cwd == nil, let c = obj["cwd"] as? String, !c.isEmpty {
+                    cwd = c
+                }
+                if model == nil { model = extractModel(from: obj) }
+                if let ts = extractTimestamp(from: obj) {
+                    if tmin == nil || ts < tmin! { tmin = ts }
+                    if tmax == nil || ts > tmax! { tmax = ts }
+                }
+                let type = (obj["type"] as? String)?.lowercased() ?? ""
+                switch type {
+                case "message":
+                    let role = (obj["role"] as? String)?.lowercased() ?? ""
+                    if role == "user" || role == "assistant" { messageCount += 1 }
+                    if firstUser == nil, role == "user", let t = stringifyContent(obj["content"]), !t.isEmpty {
+                        firstUser = truncateTitle(t)
+                    }
+                case "function_call":
+                    toolCount += 1
+                default:
+                    break
+                }
+                return true
+            }
+        } catch {
+            return nil
+        }
+
+        guard messageCount > 0 else { return nil }
+
+        let sid = forcedID ?? sha256(path: url.path)
+        let repo = cwd.flatMap { URL(fileURLWithPath: $0).lastPathComponent }
+
+        return Session(
+            id: sid,
+            source: source,
+            startTime: tmin ?? ctime,
+            endTime: tmax ?? mtime,
+            model: model,
+            filePath: url.path,
+            fileSizeBytes: size >= 0 ? size : nil,
+            eventCount: max(messageCount + toolCount, messageCount),
+            events: [],
+            cwd: cwd,
+            repoName: repo,
+            lightweightTitle: firstUser,
+            lightweightCommands: toolCount > 0 ? toolCount : nil,
+            codexInternalSessionIDHint: sessionHint
+        )
+    }
+
+    // MARK: - Full parse
+
+    static func parseFileFull(at url: URL, source: SessionSource, forcedID: String? = nil) -> Session? {
+        assert(source == .codebuddy || source == .workbuddy)
+        let attrs = (try? FileManager.default.attributesOfItem(atPath: url.path)) ?? [:]
+        let size = (attrs[.size] as? NSNumber)?.intValue ?? -1
+        let mtime = (attrs[.modificationDate] as? Date) ?? Date()
+        let ctime = (attrs[.creationDate] as? Date) ?? mtime
+
+        let reader = JSONLReader(url: url)
+        var events: [SessionEvent] = []
+        events.reserveCapacity(256)
+        var idx = 0
+        var sessionHint: String?
+        var cwd: String?
+        var model: String?
+        var tmin: Date?
+        var tmax: Date?
+        let eventIDPrefix = sha256(path: url.path).prefix(12)
+
+        do {
+            try reader.forEachLine { rawLine in
+                idx += 1
+                guard let data = rawLine.data(using: .utf8),
+                      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    return
+                }
+                if sessionHint == nil, let sid = obj["sessionId"] as? String, !sid.isEmpty {
+                    sessionHint = sid
+                }
+                if cwd == nil, let c = obj["cwd"] as? String, !c.isEmpty {
+                    cwd = c
+                }
+                if model == nil { model = extractModel(from: obj) }
+                if let ts = extractTimestamp(from: obj) {
+                    if tmin == nil || ts < tmin! { tmin = ts }
+                    if tmax == nil || ts > tmax! { tmax = ts }
+                }
+                let baseID = "\(eventIDPrefix)-\(idx)"
+                events.append(contentsOf: parseLineEvents(obj, baseEventID: baseID))
+            }
+        } catch {
+            return nil
+        }
+
+        let sid = forcedID ?? sha256(path: url.path)
+        let repo = cwd.flatMap { URL(fileURLWithPath: $0).lastPathComponent }
+        let nonMeta = events.filter { $0.kind != .meta }.count
+        let isHousekeeping = Session.computeIsHousekeeping(source: source, events: events)
+        let toolCallCount = events.filter { $0.kind == .tool_call }.count
+        let lightweightTitle: String? = events.lazy.compactMap { e -> String? in
+            guard e.kind == .user, let t = e.text?.trimmingCharacters(in: .whitespacesAndNewlines), !t.isEmpty else { return nil }
+            return truncateTitle(t)
+        }.first
+
+        return Session(
+            id: sid,
+            source: source,
+            startTime: tmin ?? ctime,
+            endTime: tmax ?? mtime,
+            model: model,
+            filePath: url.path,
+            fileSizeBytes: size >= 0 ? size : nil,
+            eventCount: max(nonMeta, events.filter { $0.kind == .user || $0.kind == .assistant }.count),
+            events: events,
+            cwd: cwd,
+            repoName: repo,
+            lightweightTitle: lightweightTitle,
+            lightweightCommands: toolCallCount > 0 ? toolCallCount : nil,
+            isHousekeeping: isHousekeeping,
+            codexInternalSessionIDHint: sessionHint
+        )
+    }
+
+    // MARK: - Line parsing
+
+    private static func parseLineEvents(_ obj: [String: Any], baseEventID: String) -> [SessionEvent] {
+        let rawJSON = rawJSONBase64(truncateLargeStrings(in: obj))
+        let ts = extractTimestamp(from: obj)
+        guard let typeRaw = obj["type"] as? String else {
+            return [metaEvent(id: baseEventID, ts: ts, text: "(missing type)", raw: rawJSON)]
+        }
+        let type = typeRaw.lowercased()
+        switch type {
+        case "message":
+            let roleRaw = (obj["role"] as? String)?.lowercased() ?? "assistant"
+            let role: String
+            let kind: SessionEventKind
+            switch roleRaw {
+            case "user", "human":
+                role = "user"; kind = .user
+            case "assistant", "model":
+                role = "assistant"; kind = .assistant
+            case "system":
+                role = "system"; kind = .meta
+            default:
+                role = roleRaw
+                kind = .assistant
+            }
+            let text = stringifyContent(obj["content"])
+            return [
+                SessionEvent(
+                    id: baseEventID,
+                    timestamp: ts,
+                    kind: kind,
+                    role: role,
+                    text: text,
+                    toolName: nil,
+                    toolInput: nil,
+                    toolOutput: nil,
+                    messageID: obj["id"] as? String,
+                    parentID: obj["parentId"] as? String,
+                    isDelta: false,
+                    rawJSON: rawJSON
+                )
+            ]
+        case "function_call":
+            let name = (obj["name"] as? String) ?? "tool"
+            let input = stringifyJSONValue(obj["arguments"]) ?? stringifyJSONValue(obj["message"])
+            return [
+                SessionEvent(
+                    id: baseEventID,
+                    timestamp: ts,
+                    kind: .tool_call,
+                    role: "assistant",
+                    text: nil,
+                    toolName: name,
+                    toolInput: input,
+                    toolOutput: nil,
+                    messageID: obj["id"] as? String,
+                    parentID: obj["parentId"] as? String,
+                    isDelta: false,
+                    rawJSON: rawJSON
+                )
+            ]
+        case "function_call_result":
+            let name = (obj["name"] as? String) ?? "tool"
+            let output = stringifyJSONValue(obj["output"]) ?? stringifyJSONValue(obj["message"])
+            return [
+                SessionEvent(
+                    id: baseEventID,
+                    timestamp: ts,
+                    kind: .tool_result,
+                    role: "tool",
+                    text: nil,
+                    toolName: name,
+                    toolInput: nil,
+                    toolOutput: output,
+                    messageID: obj["id"] as? String,
+                    parentID: obj["parentId"] as? String,
+                    isDelta: false,
+                    rawJSON: rawJSON
+                )
+            ]
+        case "reasoning":
+            let body = (obj["rawContent"] as? String) ?? stringifyContent(obj["content"])
+            return [
+                SessionEvent(
+                    id: baseEventID,
+                    timestamp: ts,
+                    kind: .meta,
+                    role: "assistant",
+                    text: body.map { "[reasoning]\n\($0)" },
+                    toolName: nil,
+                    toolInput: nil,
+                    toolOutput: nil,
+                    messageID: obj["id"] as? String,
+                    parentID: obj["parentId"] as? String,
+                    isDelta: false,
+                    rawJSON: rawJSON
+                )
+            ]
+        case "topic", "file-history-snapshot":
+            let summary: String = {
+                if type == "topic", let t = obj["topic"] as? String { return "[topic] \(t)" }
+                return "[\(type)]"
+            }()
+            return [metaEvent(id: baseEventID, ts: ts, text: summary, raw: rawJSON)]
+        default:
+            let mapped = SessionEventKind.from(role: nil, type: type)
+            if mapped == .meta {
+                return [metaEvent(id: baseEventID, ts: ts, text: "[\(type)]", raw: rawJSON)]
+            }
+            return [
+                SessionEvent(
+                    id: baseEventID,
+                    timestamp: ts,
+                    kind: mapped,
+                    role: "meta",
+                    text: nil,
+                    toolName: nil,
+                    toolInput: nil,
+                    toolOutput: nil,
+                    messageID: nil,
+                    parentID: nil,
+                    isDelta: false,
+                    rawJSON: rawJSON
+                )
+            ]
+        }
+    }
+
+    private static func metaEvent(id: String, ts: Date?, text: String, raw: String) -> SessionEvent {
+        SessionEvent(
+            id: id,
+            timestamp: ts,
+            kind: .meta,
+            role: "meta",
+            text: text,
+            toolName: nil,
+            toolInput: nil,
+            toolOutput: nil,
+            messageID: nil,
+            parentID: nil,
+            isDelta: false,
+            rawJSON: raw
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func extractTimestamp(from obj: [String: Any]) -> Date? {
+        if let n = obj["timestamp"] as? NSNumber {
+            return Date(timeIntervalSince1970: n.doubleValue / 1000.0)
+        }
+        if let i = obj["timestamp"] as? Int {
+            return Date(timeIntervalSince1970: Double(i) / 1000.0)
+        }
+        if let s = obj["timestamp"] as? String {
+            return ISO8601DateFormatter().date(from: s)
+        }
+        return nil
+    }
+
+    private static func extractModel(from obj: [String: Any]) -> String? {
+        if let pd = obj["providerData"] as? [String: Any] {
+            if let m = pd["model"] as? String, !m.isEmpty { return m }
+            if let m = pd["modelId"] as? String, !m.isEmpty { return m }
+        }
+        return nil
+    }
+
+    private static func stringifyContent(_ value: Any?) -> String? {
+        if let s = value as? String { return s }
+        if let arr = value as? [Any] {
+            var parts: [String] = []
+            for item in arr {
+                if let d = item as? [String: Any] {
+                    if let t = d["text"] as? String { parts.append(t); continue }
+                    if let t = d["content"] as? String { parts.append(t); continue }
+                    if let sub = stringifyJSONValue(d) { parts.append(sub) }
+                } else if let s = item as? String {
+                    parts.append(s)
+                }
+            }
+            let joined = parts.joined(separator: "\n")
+            return joined.isEmpty ? nil : joined
+        }
+        return stringifyJSONValue(value)
+    }
+
+    private static func stringifyJSONValue(_ value: Any?) -> String? {
+        guard let value else { return nil }
+        if let s = value as? String { return s }
+        if JSONSerialization.isValidJSONObject(value),
+           let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        return String(describing: value)
+    }
+
+    private static func truncateLargeStrings(in obj: [String: Any]) -> [String: Any] {
+        var out: [String: Any] = [:]
+        for (k, v) in obj {
+            if let s = v as? String, s.utf8.count > maxRawJSONFieldBytes {
+                out[k] = String(s.prefix(maxRawJSONFieldBytes / 2)) + "...[truncated]"
+            } else if let d = v as? [String: Any] {
+                out[k] = truncateLargeStrings(in: d)
+            } else {
+                out[k] = v
+            }
+        }
+        return out
+    }
+
+    private static func rawJSONBase64(_ obj: [String: Any]) -> String {
+        guard JSONSerialization.isValidJSONObject(obj),
+              let data = try? JSONSerialization.data(withJSONObject: obj, options: []),
+              let s = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        let capped = s.utf8.count > maxRawJSONFieldBytes ? String(s.prefix(maxRawJSONFieldBytes)) + "..." : s
+        return Data(capped.utf8).base64EncodedString()
+    }
+
+    private static func sha256(path: String) -> String {
+        let digest = SHA256.hash(data: Data(path.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func truncateTitle(_ s: String, max: Int = 80) -> String {
+        if s.count <= max { return s }
+        return String(s.prefix(max)) + "..."
+    }
+}
+
+/// Parser entry point for CodeBuddy JSONL sessions.
+enum CodebuddySessionParser {
+    static func parseFile(at url: URL, forcedID: String? = nil) -> Session? {
+        BuddyJSONLTranscriptParsing.parseFile(at: url, source: .codebuddy, forcedID: forcedID)
+    }
+
+    static func parseFileFull(at url: URL, forcedID: String? = nil) -> Session? {
+        BuddyJSONLTranscriptParsing.parseFileFull(at: url, source: .codebuddy, forcedID: forcedID)
+    }
+}
+
+/// Parser entry point for WorkBuddy JSONL sessions (structure may diverge from CodeBuddy over time).
+enum WorkbuddySessionParser {
+    static func parseFile(at url: URL, forcedID: String? = nil) -> Session? {
+        BuddyJSONLTranscriptParsing.parseFile(at: url, source: .workbuddy, forcedID: forcedID)
+    }
+
+    static func parseFileFull(at url: URL, forcedID: String? = nil) -> Session? {
+        BuddyJSONLTranscriptParsing.parseFileFull(at: url, source: .workbuddy, forcedID: forcedID)
+    }
+}

--- a/AgentSessions/Services/SessionArchiveManager.swift
+++ b/AgentSessions/Services/SessionArchiveManager.swift
@@ -447,6 +447,28 @@ final class SessionArchiveManager: ObservableObject, @unchecked Sendable {
                     map[s.id] = url
                 }
             }
+        case .codebuddy:
+            let c = defaults.string(forKey: PreferencesKey.Paths.buddyCodebuddyProjectsRootOverride) ?? ""
+            let discovery = BuddySessionDiscovery(
+                codebuddyProjectsRoot: c.isEmpty ? nil : c,
+                workbuddyProjectsRoot: nil,
+                scanCodebuddy: true,
+                scanWorkbuddy: false
+            )
+            for url in discovery.discoverSessionFiles() {
+                map[sha256Hex(url.path)] = url
+            }
+        case .workbuddy:
+            let w = defaults.string(forKey: PreferencesKey.Paths.buddyWorkbuddyProjectsRootOverride) ?? ""
+            let discovery = BuddySessionDiscovery(
+                codebuddyProjectsRoot: nil,
+                workbuddyProjectsRoot: w.isEmpty ? nil : w,
+                scanCodebuddy: false,
+                scanWorkbuddy: true
+            )
+            for url in discovery.discoverSessionFiles() {
+                map[sha256Hex(url.path)] = url
+            }
         }
 
         return map
@@ -474,6 +496,10 @@ final class SessionArchiveManager: ObservableObject, @unchecked Sendable {
             return OpenClawSessionParser.parseFile(at: upstreamURL, forcedID: sessionID) ?? minimalSession(source: source, id: sessionID, url: upstreamURL)
         case .cursor:
             return CursorSessionParser.parseFile(at: upstreamURL) ?? minimalSession(source: source, id: sessionID, url: upstreamURL)
+        case .codebuddy:
+            return CodebuddySessionParser.parseFile(at: upstreamURL) ?? minimalSession(source: source, id: sessionID, url: upstreamURL)
+        case .workbuddy:
+            return WorkbuddySessionParser.parseFile(at: upstreamURL) ?? minimalSession(source: source, id: sessionID, url: upstreamURL)
         }
     }
 

--- a/AgentSessions/Services/StarredSessionsStore.swift
+++ b/AgentSessions/Services/StarredSessionsStore.swift
@@ -14,7 +14,16 @@ struct StarredSessionKey: Hashable {
     init?(persistedString: String) {
         let parts = persistedString.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
         guard parts.count == 2 else { return nil }
-        guard let source = SessionSource(rawValue: String(parts[0])) else { return nil }
+        let rawSource = String(parts[0])
+        let source: SessionSource
+        if let s = SessionSource(rawValue: rawSource) {
+            source = s
+        } else if rawSource == "buddy" {
+            // Legacy starred keys used a single "buddy" lane before CodeBuddy/WorkBuddy split.
+            source = .codebuddy
+        } else {
+            return nil
+        }
         let id = String(parts[1])
         guard !id.isEmpty else { return nil }
         self.source = source

--- a/AgentSessions/Services/TranscriptColorSystem.swift
+++ b/AgentSessions/Services/TranscriptColorSystem.swift
@@ -78,6 +78,12 @@ enum TranscriptColorSystem {
         case .cursor:
             // Teal-ish (Cursor brand).
             return NSColor(calibratedRed: 0.20, green: 0.60, blue: 0.70, alpha: 1.0)
+        case .codebuddy:
+            // Blue-violet, distinct from Codex and Cursor.
+            return NSColor(calibratedRed: 0.38, green: 0.36, blue: 0.92, alpha: 1.0)
+        case .workbuddy:
+            // Cyan-green, distinct from Droid and Cursor.
+            return NSColor(calibratedRed: 0.10, green: 0.66, blue: 0.56, alpha: 1.0)
         }
     }
 

--- a/AgentSessions/Services/UnifiedSessionIndexer.swift
+++ b/AgentSessions/Services/UnifiedSessionIndexer.swift
@@ -34,9 +34,9 @@ struct DirectorySignatureSnapshot: Equatable {
 /// Aggregates all agent sessions into a single list with unified filters and search.
 final class UnifiedSessionIndexer: ObservableObject {
     private typealias IndexingErrorHead = (String?, String?, String?, String?)
-    private typealias IndexingErrorTail = (String?, (String?, String?, String?, String?))
+    private typealias IndexingErrorTail = (String?, ((String?, String?, String?, String?), (String?, String?)))
     private typealias AgentEnablementHead = (Bool, Bool, Bool, Bool)
-    private typealias AgentEnablementTail = (Bool, (Bool, Bool, Bool, Bool))
+    private typealias AgentEnablementTail = (Bool, ((Bool, Bool, Bool, Bool), (Bool, Bool)))
 
     enum CoreIndexingDisplayMode: Equatable {
         case idle
@@ -76,7 +76,9 @@ final class UnifiedSessionIndexer: ObservableObject {
         .copilot: defaultFocusedSessionRefreshIntervals,
         .droid: defaultFocusedSessionRefreshIntervals,
         .openclaw: defaultFocusedSessionRefreshIntervals,
-        .cursor: defaultFocusedSessionRefreshIntervals
+        .cursor: defaultFocusedSessionRefreshIntervals,
+        .codebuddy: defaultFocusedSessionRefreshIntervals,
+        .workbuddy: defaultFocusedSessionRefreshIntervals
     ]
     private struct FileSignature: Equatable {
         let path: String
@@ -280,6 +282,46 @@ final class UnifiedSessionIndexer: ObservableObject {
                 }
                 indexer.cursor.reloadSession(id: context.sessionID, force: force, reason: reason)
             }
+        ),
+        .codebuddy: FocusedMonitorCapability(
+            supportsFocusedMonitoring: { true },
+            signatureSource: { indexer, context in
+                indexer.sourceAwareFocusedSignaturePath(for: context)
+            },
+            reloadFocusedSession: { indexer, context, trigger in
+                guard indexer.codebuddyAgentEnabled else { return }
+                let force = (trigger != .selection)
+                let reason: BuddySessionIndexer.ReloadReason
+                switch trigger {
+                case .selection:
+                    reason = .selection
+                case .monitor:
+                    reason = .focusedSessionMonitor
+                case .manual:
+                    reason = .manualRefresh
+                }
+                indexer.codebuddy.reloadSession(id: context.sessionID, force: force, reason: reason)
+            }
+        ),
+        .workbuddy: FocusedMonitorCapability(
+            supportsFocusedMonitoring: { true },
+            signatureSource: { indexer, context in
+                indexer.sourceAwareFocusedSignaturePath(for: context)
+            },
+            reloadFocusedSession: { indexer, context, trigger in
+                guard indexer.workbuddyAgentEnabled else { return }
+                let force = (trigger != .selection)
+                let reason: BuddySessionIndexer.ReloadReason
+                switch trigger {
+                case .selection:
+                    reason = .selection
+                case .monitor:
+                    reason = .focusedSessionMonitor
+                case .manual:
+                    reason = .manualRefresh
+                }
+                indexer.workbuddy.reloadSession(id: context.sessionID, force: force, reason: reason)
+            }
         )
     ]
 
@@ -380,6 +422,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         let droid: Bool
         let openClaw: Bool
         let cursor: Bool
+        let codebuddy: Bool
+        let workbuddy: Bool
     }
 
     struct SessionAggregationWork {
@@ -392,6 +436,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         let droidList: [Session]
         let openclawList: [Session]
         let cursorList: [Session]
+        let codebuddyList: [Session]
+        let workbuddyList: [Session]
         let favoritesSnapshot: FavoritesStore.Snapshot
         let favoritesVersion: UInt64
         let enablement: AgentEnablementSnapshot
@@ -406,6 +452,8 @@ final class UnifiedSessionIndexer: ObservableObject {
             droidList: [],
             openclawList: [],
             cursorList: [],
+            codebuddyList: [],
+            workbuddyList: [],
             favoritesSnapshot: FavoritesStore.Snapshot(legacyIDs: [], scopedKeys: []),
             favoritesVersion: 0,
             enablement: AgentEnablementSnapshot(
@@ -417,7 +465,9 @@ final class UnifiedSessionIndexer: ObservableObject {
                 copilot: false,
                 droid: false,
                 openClaw: false,
-                cursor: false
+                cursor: false,
+                codebuddy: false,
+                workbuddy: false
             )
         )
     }
@@ -520,6 +570,18 @@ final class UnifiedSessionIndexer: ObservableObject {
             recomputeNow()
         }
     }
+    @Published var includeCodebuddy: Bool = UserDefaults.standard.object(forKey: "IncludeCodebuddySessions") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(includeCodebuddy, forKey: "IncludeCodebuddySessions")
+            recomputeNow()
+        }
+    }
+    @Published var includeWorkbuddy: Bool = UserDefaults.standard.object(forKey: "IncludeWorkbuddySessions") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(includeWorkbuddy, forKey: "IncludeWorkbuddySessions")
+            recomputeNow()
+        }
+    }
 
     // Global agent enablement (drives app-wide availability)
     @Published private(set) var codexAgentEnabled: Bool = AgentEnablement.isEnabled(.codex)
@@ -531,6 +593,8 @@ final class UnifiedSessionIndexer: ObservableObject {
     @Published private(set) var droidAgentEnabled: Bool = AgentEnablement.isEnabled(.droid)
     @Published private(set) var openClawAgentEnabled: Bool = UserDefaults.standard.object(forKey: PreferencesKey.Agents.openClawEnabled) as? Bool ?? false
     @Published private(set) var cursorAgentEnabled: Bool = AgentEnablement.isEnabled(.cursor)
+    @Published private(set) var codebuddyAgentEnabled: Bool = AgentEnablement.isEnabled(.codebuddy)
+    @Published private(set) var workbuddyAgentEnabled: Bool = AgentEnablement.isEnabled(.workbuddy)
 
     /// Providers detected on disk that the user hasn't been notified about yet.
     @Published private(set) var newlyAvailableProviders: [SessionSource] = []
@@ -571,6 +635,8 @@ final class UnifiedSessionIndexer: ObservableObject {
     private let droid: DroidSessionIndexer
     private let openclaw: OpenClawSessionIndexer
     private let cursor: CursorSessionIndexer
+    private let codebuddy: BuddySessionIndexer
+    private let workbuddy: BuddySessionIndexer
     private static let aggregationQueue = DispatchQueue(label: "UnifiedSessionIndexer.Aggregation", qos: .userInitiated)
     private var cancellables = Set<AnyCancellable>()
     private var notificationObserverTokens: [NSObjectProtocol] = []
@@ -620,7 +686,10 @@ final class UnifiedSessionIndexer: ObservableObject {
          copilotIndexer: CopilotSessionIndexer,
          droidIndexer: DroidSessionIndexer,
          openclawIndexer: OpenClawSessionIndexer,
-         cursorIndexer: CursorSessionIndexer) {
+         cursorIndexer: CursorSessionIndexer,
+         codebuddyIndexer: BuddySessionIndexer,
+         workbuddyIndexer: BuddySessionIndexer) {
+        AgentEnablement.migrateBuddyAgentSplitIfNeeded()
         self.codex = codexIndexer
         self.claude = claudeIndexer
         self.gemini = geminiIndexer
@@ -630,6 +699,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         self.droid = droidIndexer
         self.openclaw = openclawIndexer
         self.cursor = cursorIndexer
+        self.codebuddy = codebuddyIndexer
+        self.workbuddy = workbuddyIndexer
         self.analyticsLastBuiltAt = UserDefaults.standard.object(forKey: Self.analyticsLastBuiltAtDefaultsKey) as? Date
 
         syncAgentEnablementFromDefaults()
@@ -645,7 +716,10 @@ final class UnifiedSessionIndexer: ObservableObject {
             Publishers.CombineLatest4($codexAgentEnabled, $claudeAgentEnabled, $geminiAgentEnabled, $openCodeAgentEnabled),
             Publishers.CombineLatest(
                 $hermesAgentEnabled,
-                Publishers.CombineLatest4($copilotAgentEnabled, $droidAgentEnabled, $openClawAgentEnabled, $cursorAgentEnabled)
+                Publishers.CombineLatest(
+                    Publishers.CombineLatest4($copilotAgentEnabled, $droidAgentEnabled, $openClawAgentEnabled, $cursorAgentEnabled),
+                    Publishers.CombineLatest($codebuddyAgentEnabled, $workbuddyAgentEnabled)
+                )
             )
         )
 
@@ -654,7 +728,10 @@ final class UnifiedSessionIndexer: ObservableObject {
             Publishers.CombineLatest4(codex.$allSessions, claude.$allSessions, gemini.$allSessions, opencode.$allSessions),
             Publishers.CombineLatest(
                 hermes.$allSessions,
-                Publishers.CombineLatest4(copilot.$allSessions, droid.$allSessions, openclaw.$allSessions, cursor.$allSessions)
+                Publishers.CombineLatest(
+                    Publishers.CombineLatest4(copilot.$allSessions, droid.$allSessions, openclaw.$allSessions, cursor.$allSessions),
+                    Publishers.CombineLatest(codebuddy.$allSessions, workbuddy.$allSessions)
+                )
             )
         )
             .combineLatest(agentEnabledFlags, favoritesAggregationVersion)
@@ -664,11 +741,15 @@ final class UnifiedSessionIndexer: ObservableObject {
                 let (combined, tail) = sourceLists
                 let (codexList, claudeList, geminiList, opencodeList) = combined
                 let (hermesList, tailLists) = tail
-                let (copilotList, droidList, openclawList, cursorList) = tailLists
+                let (cursorPack, buddyPair) = tailLists
+                let (copilotList, droidList, openclawList, cursorList) = cursorPack
+                let (codebuddyList, workbuddyList) = buddyPair
                 let (enabled4, enabledTail) = flags
                 let (codexEnabled, claudeEnabled, geminiEnabled, openCodeEnabled) = enabled4
                 let (hermesEnabled, tailEnabled) = enabledTail
-                let (copilotEnabled, droidEnabled, openClawEnabled, cursorEnabled) = tailEnabled
+                let (cursorFlags, buddyFlags) = tailEnabled
+                let (copilotEnabled, droidEnabled, openClawEnabled, cursorEnabled) = cursorFlags
+                let (eCodebuddy, eWorkbuddy) = buddyFlags
                 return SessionAggregationWork(
                     codexList: codexList,
                     claudeList: claudeList,
@@ -679,6 +760,8 @@ final class UnifiedSessionIndexer: ObservableObject {
                     droidList: droidList,
                     openclawList: openclawList,
                     cursorList: cursorList,
+                    codebuddyList: codebuddyList,
+                    workbuddyList: workbuddyList,
                     favoritesSnapshot: self.favorites.snapshot(),
                     favoritesVersion: favoritesVersion,
                     enablement: AgentEnablementSnapshot(
@@ -690,7 +773,9 @@ final class UnifiedSessionIndexer: ObservableObject {
                         copilot: copilotEnabled,
                         droid: droidEnabled,
                         openClaw: openClawEnabled,
-                        cursor: cursorEnabled
+                        cursor: cursorEnabled,
+                        codebuddy: eCodebuddy,
+                        workbuddy: eWorkbuddy
                     )
                 )
             }
@@ -713,7 +798,11 @@ final class UnifiedSessionIndexer: ObservableObject {
             Publishers.CombineLatest4(codex.$isIndexing, claude.$isIndexing, gemini.$isIndexing, opencode.$isIndexing),
             Publishers.CombineLatest(
                 hermes.$isIndexing,
-                Publishers.CombineLatest4(copilot.$isIndexing, droid.$isIndexing, openclaw.$isIndexing, cursor.$isIndexing)
+                Publishers.CombineLatest(
+                    Publishers.CombineLatest4(copilot.$isIndexing, droid.$isIndexing, openclaw.$isIndexing, cursor.$isIndexing),
+                    Publishers.CombineLatest(codebuddy.$isIndexing, workbuddy.$isIndexing)
+                        .map { $0 || $1 }
+                )
             )
         )
             .combineLatest(agentEnabledFlags)
@@ -721,12 +810,15 @@ final class UnifiedSessionIndexer: ObservableObject {
                 let (s4, statesTail) = states
                 let (c, cl, g, o) = s4
                 let (hermesState, tailStates) = statesTail
-                let (copilotState, droidState, openclawState, cursorState) = tailStates
+                let (inner4, buddyState) = tailStates
+                let (copilotState, droidState, openclawState, cursorState) = inner4
                 let (f4, flagsTail) = flags
                 let (ec, ecl, eg, eo) = f4
                 let (eHermes, tailFlags) = flagsTail
-                let (eCopilot, eDroid, eOpenClaw, eCursor) = tailFlags
-                return (ec && c) || (ecl && cl) || (eg && g) || (eo && o) || (eHermes && hermesState) || (eCopilot && copilotState) || (eDroid && droidState) || (eOpenClaw && openclawState) || (eCursor && cursorState)
+                let (innerFlags, buddyEnablePair) = tailFlags
+                let (eCopilot, eDroid, eOpenClaw, eCursor) = innerFlags
+                let (eCodebuddy, eWorkbuddy) = buddyEnablePair
+                return (ec && c) || (ecl && cl) || (eg && g) || (eo && o) || (eHermes && hermesState) || (eCopilot && copilotState) || (eDroid && droidState) || (eOpenClaw && openclawState) || (eCursor && cursorState) || ((eCodebuddy || eWorkbuddy) && buddyState)
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
@@ -740,27 +832,36 @@ final class UnifiedSessionIndexer: ObservableObject {
             .store(in: &cancellables)
 
         // Aggregate core indexing progress across enabled providers.
-        // Provider tuple order is fixed: codex, claude, gemini, opencode, hermes, copilot, droid, openclaw, cursor.
+        // Provider tuple order is fixed: codex, claude, gemini, opencode, hermes, copilot, droid, openclaw, cursor, codebuddy, workbuddy.
         Publishers.CombineLatest3(
             Publishers.CombineLatest(
                 Publishers.CombineLatest4(codex.$filesProcessed, claude.$filesProcessed, gemini.$filesProcessed, opencode.$filesProcessed),
                 Publishers.CombineLatest(
                     hermes.$filesProcessed,
-                    Publishers.CombineLatest4(copilot.$filesProcessed, droid.$filesProcessed, openclaw.$filesProcessed, cursor.$filesProcessed)
+                    Publishers.CombineLatest(
+                        Publishers.CombineLatest4(copilot.$filesProcessed, droid.$filesProcessed, openclaw.$filesProcessed, cursor.$filesProcessed),
+                        Publishers.CombineLatest(codebuddy.$filesProcessed, workbuddy.$filesProcessed)
+                    )
                 )
             ),
             Publishers.CombineLatest(
                 Publishers.CombineLatest4(codex.$totalFiles, claude.$totalFiles, gemini.$totalFiles, opencode.$totalFiles),
                 Publishers.CombineLatest(
                     hermes.$totalFiles,
-                    Publishers.CombineLatest4(copilot.$totalFiles, droid.$totalFiles, openclaw.$totalFiles, cursor.$totalFiles)
+                    Publishers.CombineLatest(
+                        Publishers.CombineLatest4(copilot.$totalFiles, droid.$totalFiles, openclaw.$totalFiles, cursor.$totalFiles),
+                        Publishers.CombineLatest(codebuddy.$totalFiles, workbuddy.$totalFiles)
+                    )
                 )
             ),
             Publishers.CombineLatest(
                 Publishers.CombineLatest4(codex.$isIndexing, claude.$isIndexing, gemini.$isIndexing, opencode.$isIndexing),
                 Publishers.CombineLatest(
                     hermes.$isIndexing,
-                    Publishers.CombineLatest4(copilot.$isIndexing, droid.$isIndexing, openclaw.$isIndexing, cursor.$isIndexing)
+                    Publishers.CombineLatest(
+                        Publishers.CombineLatest4(copilot.$isIndexing, droid.$isIndexing, openclaw.$isIndexing, cursor.$isIndexing),
+                        Publishers.CombineLatest(codebuddy.$isIndexing, workbuddy.$isIndexing)
+                    )
                 )
             )
         )
@@ -782,7 +883,11 @@ final class UnifiedSessionIndexer: ObservableObject {
             Publishers.CombineLatest4(codex.$isProcessingTranscripts, claude.$isProcessingTranscripts, gemini.$isProcessingTranscripts, opencode.$isProcessingTranscripts),
             Publishers.CombineLatest(
                 hermes.$isProcessingTranscripts,
-                Publishers.CombineLatest4(copilot.$isProcessingTranscripts, droid.$isProcessingTranscripts, openclaw.$isProcessingTranscripts, cursor.$isProcessingTranscripts)
+                Publishers.CombineLatest(
+                    Publishers.CombineLatest4(copilot.$isProcessingTranscripts, droid.$isProcessingTranscripts, openclaw.$isProcessingTranscripts, cursor.$isProcessingTranscripts),
+                    Publishers.CombineLatest(codebuddy.$isProcessingTranscripts, workbuddy.$isProcessingTranscripts)
+                        .map { $0 || $1 }
+                )
             )
         )
             .combineLatest(agentEnabledFlags)
@@ -790,12 +895,15 @@ final class UnifiedSessionIndexer: ObservableObject {
                 let (s4, statesTail) = states
                 let (c, cl, g, o) = s4
                 let (hermesState, tailStates) = statesTail
-                let (copilotState, droidState, openclawState, cursorState) = tailStates
+                let (inner4, buddyState) = tailStates
+                let (copilotState, droidState, openclawState, cursorState) = inner4
                 let (f4, flagsTail) = flags
                 let (ec, ecl, eg, eo) = f4
                 let (eHermes, tailFlags) = flagsTail
-                let (eCopilot, eDroid, eOpenClaw, eCursor) = tailFlags
-                return (ec && c) || (ecl && cl) || (eg && g) || (eo && o) || (eHermes && hermesState) || (eCopilot && copilotState) || (eDroid && droidState) || (eOpenClaw && openclawState) || (eCursor && cursorState)
+                let (innerFlags, buddyEnablePair) = tailFlags
+                let (eCopilot, eDroid, eOpenClaw, eCursor) = innerFlags
+                let (eCodebuddy, eWorkbuddy) = buddyEnablePair
+                return (ec && c) || (ecl && cl) || (eg && g) || (eo && o) || (eHermes && hermesState) || (eCopilot && copilotState) || (eDroid && droidState) || (eOpenClaw && openclawState) || (eCursor && cursorState) || ((eCodebuddy || eWorkbuddy) && buddyState)
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
@@ -814,11 +922,14 @@ final class UnifiedSessionIndexer: ObservableObject {
         )
         let indexingErrorTail = Publishers.CombineLatest(
             hermes.$indexingError,
-            Publishers.CombineLatest4(
-                copilot.$indexingError,
-                droid.$indexingError,
-                openclaw.$indexingError,
-                cursor.$indexingError
+            Publishers.CombineLatest(
+                Publishers.CombineLatest4(
+                    copilot.$indexingError,
+                    droid.$indexingError,
+                    openclaw.$indexingError,
+                    cursor.$indexingError
+                ),
+                Publishers.CombineLatest(codebuddy.$indexingError, workbuddy.$indexingError)
             )
         )
         let indexingErrors = Publishers.CombineLatest(
@@ -857,7 +968,10 @@ final class UnifiedSessionIndexer: ObservableObject {
             Publishers.CombineLatest4($includeCodex, $includeClaude, $includeGemini, $includeOpenCode),
             Publishers.CombineLatest(
                 $includeHermes,
-                Publishers.CombineLatest4($includeCopilot, $includeDroid, $includeOpenClaw, $includeCursor)
+                Publishers.CombineLatest(
+                    Publishers.CombineLatest4($includeCopilot, $includeDroid, $includeOpenClaw, $includeCursor),
+                    Publishers.CombineLatest($includeCodebuddy, $includeWorkbuddy)
+                )
             )
         )
         Publishers.CombineLatest(
@@ -873,11 +987,15 @@ final class UnifiedSessionIndexer: ObservableObject {
                 let (src4, tailSources) = sources
                 let (incCodex, incClaude, incGemini, incOpenCode) = src4
                 let (incHermes, sourcesTail) = tailSources
-                let (incCopilot, incDroid, incOpenClaw, incCursor) = sourcesTail
+                let (sourcePack, buddySources) = sourcesTail
+                let (incCopilot, incDroid, incOpenClaw, incCursor) = sourcePack
+                let (incCodebuddy, incWorkbuddy) = buddySources
                 let (en4, enabledTail) = enabledFlags
                 let (enCodex, enClaude, enGemini, enOpenCode) = en4
                 let (enHermes, tailEnabled) = enabledTail
-                let (enCopilot, enDroid, enOpenClaw, enCursor) = tailEnabled
+                let (enabledPack, buddyEnabled) = tailEnabled
+                let (enCopilot, enDroid, enOpenClaw, enCursor) = enabledPack
+                let (enCodebuddy, enWorkbuddy) = buddyEnabled
                 let effectiveCodex = incCodex && enCodex
                 let effectiveClaude = incClaude && enClaude
                 let effectiveGemini = incGemini && enGemini
@@ -887,10 +1005,12 @@ final class UnifiedSessionIndexer: ObservableObject {
                 let effectiveDroid = incDroid && enDroid
                 let effectiveOpenClaw = incOpenClaw && enOpenClaw
                 let effectiveCursor = incCursor && enCursor
+                let effectiveCodebuddy = incCodebuddy && enCodebuddy
+                let effectiveWorkbuddy = incWorkbuddy && enWorkbuddy
 
                 // Start from all sessions, then apply the same filters we use elsewhere.
                 var base = all
-                if !(effectiveCodex && effectiveClaude && effectiveGemini && effectiveOpenCode && effectiveHermes && effectiveCopilot && effectiveDroid && effectiveOpenClaw && effectiveCursor) {
+                if !(effectiveCodex && effectiveClaude && effectiveGemini && effectiveOpenCode && effectiveHermes && effectiveCopilot && effectiveDroid && effectiveOpenClaw && effectiveCursor && effectiveCodebuddy && effectiveWorkbuddy) {
                     base = base.filter { s in
                         (s.source == .codex && effectiveCodex) ||
                         (s.source == .claude && effectiveClaude) ||
@@ -900,7 +1020,9 @@ final class UnifiedSessionIndexer: ObservableObject {
                         (s.source == .copilot && effectiveCopilot) ||
                         (s.source == .droid && effectiveDroid) ||
                         (s.source == .openclaw && effectiveOpenClaw) ||
-                        (s.source == .cursor && effectiveCursor)
+                        (s.source == .cursor && effectiveCursor) ||
+                        (s.source == .codebuddy && effectiveCodebuddy) ||
+                        (s.source == .workbuddy && effectiveWorkbuddy)
                     }
                 }
 
@@ -957,7 +1079,10 @@ final class UnifiedSessionIndexer: ObservableObject {
         Publishers.CombineLatest(Publishers.CombineLatest4(codex.$launchPhase, claude.$launchPhase, gemini.$launchPhase, opencode.$launchPhase),
                                 Publishers.CombineLatest(
                                     hermes.$launchPhase,
-                                    Publishers.CombineLatest4(copilot.$launchPhase, droid.$launchPhase, openclaw.$launchPhase, cursor.$launchPhase)
+                                    Publishers.CombineLatest(
+                                        Publishers.CombineLatest4(copilot.$launchPhase, droid.$launchPhase, openclaw.$launchPhase, cursor.$launchPhase),
+                                        Publishers.CombineLatest(codebuddy.$launchPhase, workbuddy.$launchPhase)
+                                    )
                                 ))
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _, _ in
@@ -969,7 +1094,10 @@ final class UnifiedSessionIndexer: ObservableObject {
             Publishers.CombineLatest4($includeCodex, $includeClaude, $includeGemini, $includeOpenCode),
             Publishers.CombineLatest(
                 $includeHermes,
-                Publishers.CombineLatest4($includeCopilot, $includeDroid, $includeOpenClaw, $includeCursor)
+                Publishers.CombineLatest(
+                    Publishers.CombineLatest4($includeCopilot, $includeDroid, $includeOpenClaw, $includeCursor),
+                    Publishers.CombineLatest($includeCodebuddy, $includeWorkbuddy)
+                )
             )
         )
             .receive(on: DispatchQueue.main)
@@ -1008,7 +1136,9 @@ final class UnifiedSessionIndexer: ObservableObject {
             .copilot: copilotAgentEnabled,
             .droid: droidAgentEnabled,
             .openclaw: openClawAgentEnabled,
-            .cursor: cursorAgentEnabled
+            .cursor: cursorAgentEnabled,
+            .codebuddy: codebuddyAgentEnabled,
+            .workbuddy: workbuddyAgentEnabled
         ]
         let c1 = AgentEnablement.isEnabled(.codex, defaults: defaults)
         let c2 = AgentEnablement.isEnabled(.claude, defaults: defaults)
@@ -1019,6 +1149,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         let c7 = AgentEnablement.isEnabled(.droid, defaults: defaults)
         let c8 = AgentEnablement.isEnabled(.openclaw, defaults: defaults)
         let c9 = AgentEnablement.isEnabled(.cursor, defaults: defaults)
+        let c10 = AgentEnablement.isEnabled(.codebuddy, defaults: defaults)
+        let c11 = AgentEnablement.isEnabled(.workbuddy, defaults: defaults)
         if c1 != codexAgentEnabled { codexAgentEnabled = c1 }
         if c2 != claudeAgentEnabled { claudeAgentEnabled = c2 }
         if c3 != geminiAgentEnabled { geminiAgentEnabled = c3 }
@@ -1028,6 +1160,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         if c7 != droidAgentEnabled { droidAgentEnabled = c7 }
         if c8 != openClawAgentEnabled { openClawAgentEnabled = c8 }
         if c9 != cursorAgentEnabled { cursorAgentEnabled = c9 }
+        if c10 != codebuddyAgentEnabled { codebuddyAgentEnabled = c10 }
+        if c11 != workbuddyAgentEnabled { workbuddyAgentEnabled = c11 }
 
         let afterSources = enabledAnalyticsSources()
         if analyticsLastBuiltAt != nil && !afterSources.subtracting(beforeSources).isEmpty {
@@ -1078,7 +1212,9 @@ final class UnifiedSessionIndexer: ObservableObject {
             copilotAgentEnabled ? .copilot : nil,
             droidAgentEnabled ? .droid : nil,
             openClawAgentEnabled ? .openclaw : nil,
-            cursorAgentEnabled ? .cursor : nil
+            cursorAgentEnabled ? .cursor : nil,
+            codebuddyAgentEnabled ? .codebuddy : nil,
+            workbuddyAgentEnabled ? .workbuddy : nil
         ].compactMap { $0 }
         for source in sources {
             requestProviderRefresh(source: source, reason: "unified-refresh", trigger: trigger)
@@ -1123,10 +1259,14 @@ final class UnifiedSessionIndexer: ObservableObject {
     ) -> String? {
         let (codexErr, claudeErr, geminiErr, opencodeErr) = headErrors
         let (hermesErr, tailErrValues) = tailErrors
-        let (copilotErr, droidErr, openclawErr, cursorErr) = tailErrValues
+        let (tailErrPack, buddyErrPair) = tailErrValues
+        let (copilotErr, droidErr, openclawErr, cursorErr) = tailErrPack
+        let (codebuddyErr, workbuddyErr) = buddyErrPair
         let (codexEnabled, claudeEnabled, geminiEnabled, openCodeEnabled) = headFlags
         let (hermesEnabled, tailFlagValues) = tailFlags
-        let (copilotEnabled, droidEnabled, openClawEnabled, cursorEnabled) = tailFlagValues
+        let (tailFlagPack, buddyFlagPair) = tailFlagValues
+        let (copilotEnabled, droidEnabled, openClawEnabled, cursorEnabled) = tailFlagPack
+        let (codebuddyEnabled, workbuddyEnabled) = buddyFlagPair
 
         let errors: [String?] = [
             codexEnabled ? codexErr : nil,
@@ -1137,7 +1277,9 @@ final class UnifiedSessionIndexer: ObservableObject {
             copilotEnabled ? copilotErr : nil,
             droidEnabled ? droidErr : nil,
             openClawEnabled ? openclawErr : nil,
-            cursorEnabled ? cursorErr : nil
+            cursorEnabled ? cursorErr : nil,
+            codebuddyEnabled ? codebuddyErr : nil,
+            workbuddyEnabled ? workbuddyErr : nil
         ]
         return errors.compactMap { $0 }.first
     }
@@ -1146,39 +1288,47 @@ final class UnifiedSessionIndexer: ObservableObject {
         metrics: (
             (
                 (Int, Int, Int, Int),
-                (Int, (Int, Int, Int, Int))
+                (Int, ((Int, Int, Int, Int), (Int, Int)))
             ),
             (
                 (Int, Int, Int, Int),
-                (Int, (Int, Int, Int, Int))
+                (Int, ((Int, Int, Int, Int), (Int, Int)))
             ),
             (
                 (Bool, Bool, Bool, Bool),
-                (Bool, (Bool, Bool, Bool, Bool))
+                (Bool, ((Bool, Bool, Bool, Bool), (Bool, Bool)))
             )
         ),
         flags: (
             (Bool, Bool, Bool, Bool),
-            (Bool, (Bool, Bool, Bool, Bool))
+            (Bool, ((Bool, Bool, Bool, Bool), (Bool, Bool)))
         )
     ) -> [CoreProviderSnapshot] {
         let (processedTuple, totalsTuple, indexingTuple) = metrics
         let (processed4, processedTail) = processedTuple
         let (pCodex, pClaude, pGemini, pOpenCode) = processed4
         let (pHermes, processedTail4) = processedTail
-        let (pCopilot, pDroid, pOpenClaw, pCursor) = processedTail4
+        let (processedTailPack, processedBuddyPair) = processedTail4
+        let (pCopilot, pDroid, pOpenClaw, pCursor) = processedTailPack
+        let (pCodebuddy, pWorkbuddy) = processedBuddyPair
         let (totals4, totalsTail) = totalsTuple
         let (tCodex, tClaude, tGemini, tOpenCode) = totals4
         let (tHermes, totalsTail4) = totalsTail
-        let (tCopilot, tDroid, tOpenClaw, tCursor) = totalsTail4
+        let (totalsTailPack, totalsBuddyPair) = totalsTail4
+        let (tCopilot, tDroid, tOpenClaw, tCursor) = totalsTailPack
+        let (tCodebuddy, tWorkbuddy) = totalsBuddyPair
         let (index4, indexTail) = indexingTuple
         let (iCodex, iClaude, iGemini, iOpenCode) = index4
         let (iHermes, indexTail4) = indexTail
-        let (iCopilot, iDroid, iOpenClaw, iCursor) = indexTail4
+        let (indexTailPack, indexBuddyPair) = indexTail4
+        let (iCopilot, iDroid, iOpenClaw, iCursor) = indexTailPack
+        let (iCodebuddy, iWorkbuddy) = indexBuddyPair
         let (f4, flagsTail) = flags
         let (eCodex, eClaude, eGemini, eOpenCode) = f4
         let (eHermes, tailFlags) = flagsTail
-        let (eCopilot, eDroid, eOpenClaw, eCursor) = tailFlags
+        let (tailFlagPack, buddyFlagPair) = tailFlags
+        let (eCopilot, eDroid, eOpenClaw, eCursor) = tailFlagPack
+        let (eCodebuddy, eWorkbuddy) = buddyFlagPair
 
         return [
             CoreProviderSnapshot(source: .codex, enabled: eCodex, indexing: iCodex, processed: pCodex, total: tCodex),
@@ -1189,7 +1339,9 @@ final class UnifiedSessionIndexer: ObservableObject {
             CoreProviderSnapshot(source: .copilot, enabled: eCopilot, indexing: iCopilot, processed: pCopilot, total: tCopilot),
             CoreProviderSnapshot(source: .droid, enabled: eDroid, indexing: iDroid, processed: pDroid, total: tDroid),
             CoreProviderSnapshot(source: .openclaw, enabled: eOpenClaw, indexing: iOpenClaw, processed: pOpenClaw, total: tOpenClaw),
-            CoreProviderSnapshot(source: .cursor, enabled: eCursor, indexing: iCursor, processed: pCursor, total: tCursor)
+            CoreProviderSnapshot(source: .cursor, enabled: eCursor, indexing: iCursor, processed: pCursor, total: tCursor),
+            CoreProviderSnapshot(source: .codebuddy, enabled: eCodebuddy, indexing: iCodebuddy, processed: pCodebuddy, total: tCodebuddy),
+            CoreProviderSnapshot(source: .workbuddy, enabled: eWorkbuddy, indexing: iWorkbuddy, processed: pWorkbuddy, total: tWorkbuddy)
         ]
     }
 
@@ -1772,6 +1924,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         case .droid: return droidAgentEnabled && !droid.isIndexing
         case .openclaw: return openClawAgentEnabled && !openclaw.isIndexing
         case .cursor: return cursorAgentEnabled && !cursor.isIndexing
+        case .codebuddy: return codebuddyAgentEnabled && !codebuddy.isIndexing
+        case .workbuddy: return workbuddyAgentEnabled && !workbuddy.isIndexing
         }
     }
 
@@ -1885,6 +2039,10 @@ final class UnifiedSessionIndexer: ObservableObject {
             livePath = openclaw.allSessions.first(where: { $0.id == context.sessionID })?.filePath
         case .cursor:
             livePath = cursor.allSessions.first(where: { $0.id == context.sessionID })?.filePath
+        case .codebuddy:
+            livePath = codebuddy.allSessions.first(where: { $0.id == context.sessionID })?.filePath
+        case .workbuddy:
+            livePath = workbuddy.allSessions.first(where: { $0.id == context.sessionID })?.filePath
         }
         if let livePath, !livePath.isEmpty { return livePath }
         return context.filePath
@@ -1979,6 +2137,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         case .droid: droid.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
         case .openclaw: openclaw.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
         case .cursor: cursor.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
+        case .codebuddy: codebuddy.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
+        case .workbuddy: workbuddy.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
         }
     }
 
@@ -1994,6 +2154,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         case .droid: return droid.isIndexing
         case .openclaw: return openclaw.isIndexing
         case .cursor: return cursor.isIndexing
+        case .codebuddy: return codebuddy.isIndexing
+        case .workbuddy: return workbuddy.isIndexing
         }
     }
 
@@ -2202,6 +2364,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         phases[.droid] = (droidAgentEnabled && includeDroid) ? droid.launchPhase : .ready
         phases[.openclaw] = (openClawAgentEnabled && includeOpenClaw) ? openclaw.launchPhase : .ready
         phases[.cursor] = (cursorAgentEnabled && includeCursor) ? cursor.launchPhase : .ready
+        phases[.codebuddy] = (codebuddyAgentEnabled && includeCodebuddy) ? codebuddy.launchPhase : .ready
+        phases[.workbuddy] = (workbuddyAgentEnabled && includeWorkbuddy) ? workbuddy.launchPhase : .ready
 
         let overall: LaunchPhase
         if phases.values.contains(.error) {
@@ -2248,6 +2412,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         if work.enablement.droid { merged.append(contentsOf: work.droidList) }
         if work.enablement.openClaw { merged.append(contentsOf: work.openclawList) }
         if work.enablement.cursor { merged.append(contentsOf: work.cursorList) }
+        if work.enablement.codebuddy { merged.append(contentsOf: work.codebuddyList) }
+        if work.enablement.workbuddy { merged.append(contentsOf: work.workbuddyList) }
         for index in merged.indices {
             merged[index].isFavorite = work.favoritesSnapshot.contains(id: merged[index].id, source: merged[index].source)
         }
@@ -2287,6 +2453,8 @@ final class UnifiedSessionIndexer: ObservableObject {
             case .droid:    return droidAgentEnabled && includeDroid
             case .openclaw: return openClawAgentEnabled && includeOpenClaw
             case .cursor:   return cursorAgentEnabled && includeCursor
+            case .codebuddy: return codebuddyAgentEnabled && includeCodebuddy
+            case .workbuddy: return workbuddyAgentEnabled && includeWorkbuddy
             }
         }
 
@@ -2298,7 +2466,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         if hasCommandsOnly {
             results = results.filter { s in
                 // For Codex, Copilot, and OpenCode, require evidence of commands/tool calls (or lightweightCommands>0).
-                if s.source == .codex || s.source == .opencode || s.source == .hermes || s.source == .copilot || s.source == .droid || s.source == .openclaw || s.source == .cursor {
+                if s.source == .codex || s.source == .opencode || s.source == .hermes || s.source == .copilot || s.source == .droid || s.source == .openclaw || s.source == .cursor || s.source == .codebuddy || s.source == .workbuddy {
                     if !s.events.isEmpty {
                         return s.events.contains { $0.kind == .tool_call }
                     } else {
@@ -2429,7 +2597,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         let hasDisplayedSessions: Bool
 
         static let idle = LaunchState(
-            sourcePhases: [.codex: .idle, .claude: .idle, .gemini: .idle, .opencode: .idle, .copilot: .idle, .droid: .idle, .openclaw: .idle, .cursor: .idle],
+            sourcePhases: Dictionary(uniqueKeysWithValues: SessionSource.allCases.map { ($0, .idle) }),
             overallPhase: .idle,
             blockingSources: SessionSource.allCases,
             hasDisplayedSessions: false

--- a/AgentSessions/Views/BuddyTranscriptView.swift
+++ b/AgentSessions/Views/BuddyTranscriptView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import AppKit
+
+struct BuddyTranscriptView: View {
+    @ObservedObject var indexer: BuddySessionIndexer
+    let sessionID: String?
+
+    var body: some View {
+        UnifiedTranscriptView(
+            indexer: indexer,
+            sessionID: sessionID,
+            sessionIDExtractor: buddySessionID,
+            sessionIDLabel: "Buddy",
+            enableCaching: false
+        )
+    }
+
+    private func buddySessionID(for session: Session) -> String? {
+        if let hint = session.codexInternalSessionIDHint, !hint.isEmpty { return hint }
+        let base = URL(fileURLWithPath: session.filePath).deletingPathExtension().lastPathComponent
+        if base.count >= 8 { return base }
+        return nil
+    }
+}

--- a/AgentSessions/Views/CockpitView.swift
+++ b/AgentSessions/Views/CockpitView.swift
@@ -685,6 +685,8 @@ struct CockpitView: View {
         case .droid: return "Droid"
         case .openclaw: return "OpenClaw"
         case .cursor: return "Cursor"
+        case .codebuddy: return "CodeBuddy"
+        case .workbuddy: return "WorkBuddy"
         }
     }
 }

--- a/AgentSessions/Views/Preferences/PreferencesConstants.swift
+++ b/AgentSessions/Views/Preferences/PreferencesConstants.swift
@@ -48,6 +48,10 @@ enum PreferencesKey {
         static let droidEnabled = "AgentEnabledDroid"
         static let openClawEnabled = "AgentEnabledOpenClaw"
         static let cursorEnabled = "AgentEnabledCursor"
+        /// Legacy single toggle (pre split); read only for migration into CodeBuddy/WorkBuddy keys.
+        static let buddyEnabled = "AgentEnabledBuddy"
+        static let codebuddyEnabled = "AgentEnabledCodebuddy"
+        static let workbuddyEnabled = "AgentEnabledWorkbuddy"
         static let knownAvailableProviders = "KnownAvailableProviders"
     }
 
@@ -97,6 +101,8 @@ enum PreferencesKey {
         static let openClawSessionsRootOverride = "OpenClawSessionsRootOverride"
         static let openClawBinaryOverride = "OpenClawBinaryOverride"
         static let cursorSessionsRootOverride = "CursorSessionsRootOverride"
+        static let buddyCodebuddyProjectsRootOverride = "BuddyCodebuddyProjectsRootOverride"
+        static let buddyWorkbuddyProjectsRootOverride = "BuddyWorkbuddyProjectsRootOverride"
     }
 
     enum Archives {

--- a/AgentSessions/Views/Preferences/PreferencesView+General.swift
+++ b/AgentSessions/Views/Preferences/PreferencesView+General.swift
@@ -59,7 +59,7 @@ extension PreferencesView {
 
             sectionHeader("Active CLI agents")
             VStack(alignment: .leading, spacing: 6) {
-                let enabledCount = [codexAgentEnabled, claudeAgentEnabled, geminiAgentEnabled, openCodeAgentEnabled, hermesAgentEnabled, copilotAgentEnabled, droidAgentEnabled, openClawAgentEnabled, cursorAgentEnabled].filter { $0 }.count
+                let enabledCount = [codexAgentEnabled, claudeAgentEnabled, geminiAgentEnabled, openCodeAgentEnabled, hermesAgentEnabled, copilotAgentEnabled, droidAgentEnabled, openClawAgentEnabled, cursorAgentEnabled, codebuddyAgentEnabled, workbuddyAgentEnabled].filter { $0 }.count
 
                 agentEnableToggle(title: "Codex", source: .codex, isOn: $codexAgentEnabled, enabledCount: enabledCount)
                 agentEnableToggle(title: "Claude", source: .claude, isOn: $claudeAgentEnabled, enabledCount: enabledCount)
@@ -70,6 +70,8 @@ extension PreferencesView {
                 agentEnableToggle(title: "Droid", source: .droid, isOn: $droidAgentEnabled, enabledCount: enabledCount)
                 agentEnableToggle(title: "OpenClaw", source: .openclaw, isOn: $openClawAgentEnabled, enabledCount: enabledCount)
                 agentEnableToggle(title: "Cursor", source: .cursor, isOn: $cursorAgentEnabled, enabledCount: enabledCount)
+                agentEnableToggle(title: "CodeBuddy", source: .codebuddy, isOn: $codebuddyAgentEnabled, enabledCount: enabledCount)
+                agentEnableToggle(title: "WorkBuddy", source: .workbuddy, isOn: $workbuddyAgentEnabled, enabledCount: enabledCount)
 
                 Text("Disabled agents are hidden across the app and background work is paused.")
                     .font(.caption)

--- a/AgentSessions/Views/PreferencesView.swift
+++ b/AgentSessions/Views/PreferencesView.swift
@@ -76,6 +76,8 @@ struct PreferencesView: View {
     @AppStorage(PreferencesKey.Agents.droidEnabled) var droidAgentEnabled: Bool = true
     @AppStorage(PreferencesKey.Agents.openClawEnabled) var openClawAgentEnabled: Bool = false
     @AppStorage(PreferencesKey.Agents.cursorEnabled) var cursorAgentEnabled: Bool = true
+    @AppStorage(PreferencesKey.Agents.codebuddyEnabled) var codebuddyAgentEnabled: Bool = true
+    @AppStorage(PreferencesKey.Agents.workbuddyEnabled) var workbuddyAgentEnabled: Bool = true
     // Menu bar prefs
     @AppStorage(PreferencesKey.menuBarEnabled) var menuBarEnabled: Bool = false
     @AppStorage(PreferencesKey.menuBarScope) var menuBarScopeRaw: String = MenuBarScope.both.rawValue
@@ -825,6 +827,7 @@ struct PreferencesView: View {
         case .droid: scheduleDroidProbe()
         case .openclaw: scheduleOpenClawProbe()
         case .cursor: scheduleCursorProbe()
+        case .codebuddy, .workbuddy: break
         }
     }
 
@@ -848,6 +851,8 @@ struct PreferencesView: View {
             return openClawResolvedPath
         case .cursor:
             return cursorResolvedPath
+        case .codebuddy, .workbuddy:
+            return nil
         }
     }
 
@@ -880,6 +885,8 @@ struct PreferencesView: View {
         case .cursor:
             let value = cursorSettings.binaryPath
             return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : value
+        case .codebuddy, .workbuddy:
+            return nil
         }
     }
 

--- a/AgentSessions/Views/SessionTerminalView.swift
+++ b/AgentSessions/Views/SessionTerminalView.swift
@@ -199,6 +199,8 @@ struct SessionTerminalView: View {
         case .droid: return "Droid"
         case .openclaw: return "OpenClaw"
         case .cursor: return "Cursor"
+        case .codebuddy: return "CodeBuddy"
+        case .workbuddy: return "WorkBuddy"
         }
     }
 

--- a/AgentSessions/Views/UnifiedSessionsView.swift
+++ b/AgentSessions/Views/UnifiedSessionsView.swift
@@ -212,6 +212,8 @@ struct UnifiedSessionsView: View {
     let droidIndexer: DroidSessionIndexer
     let openclawIndexer: OpenClawSessionIndexer
     let cursorIndexer: CursorSessionIndexer
+    let codebuddyIndexer: BuddySessionIndexer
+    let workbuddyIndexer: BuddySessionIndexer
     @EnvironmentObject var codexUsageModel: CodexUsageModel
     @EnvironmentObject var claudeUsageModel: ClaudeUsageModel
     @EnvironmentObject var activeCodexSessions: CodexActiveSessionsModel
@@ -255,6 +257,8 @@ struct UnifiedSessionsView: View {
 	    @AppStorage(PreferencesKey.Agents.droidEnabled) private var droidAgentEnabled: Bool = true
 	    @AppStorage(PreferencesKey.Agents.openClawEnabled) private var openClawAgentEnabled: Bool = false
 	    @AppStorage(PreferencesKey.Agents.cursorEnabled) private var cursorAgentEnabled: Bool = true
+	    @AppStorage(PreferencesKey.Agents.codebuddyEnabled) private var codebuddyAgentEnabled: Bool = true
+	    @AppStorage(PreferencesKey.Agents.workbuddyEnabled) private var workbuddyAgentEnabled: Bool = true
 	    @State private var autoSelectEnabled: Bool = true
 	    @State private var isDatasetChurning: Bool = false
 	    @State private var isAutoSelectingFromSearch: Bool = false
@@ -303,6 +307,8 @@ struct UnifiedSessionsView: View {
          droidIndexer: DroidSessionIndexer,
          openclawIndexer: OpenClawSessionIndexer,
          cursorIndexer: CursorSessionIndexer,
+         codebuddyIndexer: BuddySessionIndexer,
+         workbuddyIndexer: BuddySessionIndexer,
          analyticsReady: Bool,
          analyticsPhase: AnalyticsIndexPhase,
          analyticsIsStale: Bool,
@@ -318,6 +324,8 @@ struct UnifiedSessionsView: View {
         self.droidIndexer = droidIndexer
         self.openclawIndexer = openclawIndexer
         self.cursorIndexer = cursorIndexer
+        self.codebuddyIndexer = codebuddyIndexer
+        self.workbuddyIndexer = workbuddyIndexer
         self.analyticsReady = analyticsReady
         self.analyticsPhase = analyticsPhase
         self.analyticsIsStale = analyticsIsStale
@@ -374,6 +382,16 @@ struct UnifiedSessionsView: View {
                 transcriptCache: cursorIndexer.searchTranscriptCache,
                 update: { cursorIndexer.updateSession($0) },
                 parseFull: { url, forcedID in CursorSessionParser.parseFileFull(at: url, forcedID: forcedID) }
+            ),
+            .codebuddy: .init(
+                transcriptCache: codebuddyIndexer.searchTranscriptCache,
+                update: { codebuddyIndexer.updateSession($0) },
+                parseFull: { url, forcedID in CodebuddySessionParser.parseFileFull(at: url, forcedID: forcedID) }
+            ),
+            .workbuddy: .init(
+                transcriptCache: workbuddyIndexer.searchTranscriptCache,
+                update: { workbuddyIndexer.updateSession($0) },
+                parseFull: { url, forcedID in WorkbuddySessionParser.parseFileFull(at: url, forcedID: forcedID) }
             ),
         ])
         _searchCoordinator = StateObject(wrappedValue: SearchCoordinator(store: store))
@@ -467,7 +485,11 @@ struct UnifiedSessionsView: View {
 		let afterCursor = afterOpenClaw
 			.onChange(of: unified.includeCursor) { _, _ in restartSearchIfRunning() }
 
-        let afterActiveOnly = afterCursor
+		let afterBuddyFilters = afterCursor
+			.onChange(of: unified.includeCodebuddy) { _, _ in restartSearchIfRunning() }
+			.onChange(of: unified.includeWorkbuddy) { _, _ in restartSearchIfRunning() }
+
+        let afterActiveOnly = afterBuddyFilters
             .onChange(of: showActiveSessionsOnly) { _, _ in
                 if !liveSessionsFeatureEnabled {
                     showActiveSessionsOnly = false
@@ -520,6 +542,8 @@ struct UnifiedSessionsView: View {
 			.onChange(of: geminiAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
 			.onChange(of: openCodeAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
 			.onChange(of: copilotAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
+			.onChange(of: codebuddyAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
+			.onChange(of: workbuddyAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
 
 		let afterSessions = afterAgents
 			.onReceive(unified.$sessions) { sessions in
@@ -1198,7 +1222,9 @@ struct UnifiedSessionsView: View {
                                copilotIndexer: copilotIndexer,
                                droidIndexer: droidIndexer,
                                openclawIndexer: openclawIndexer,
-                               cursorIndexer: cursorIndexer)
+                               cursorIndexer: cursorIndexer,
+                               codebuddyIndexer: codebuddyIndexer,
+                               workbuddyIndexer: workbuddyIndexer)
                 .environmentObject(focusCoordinator)
                 .environmentObject(searchState)
                 .id("transcript-host")
@@ -1219,6 +1245,8 @@ struct UnifiedSessionsView: View {
                         case .droid: return "Droid"
                         case .openclaw: return "OpenClaw"
                         case .cursor: return "Cursor"
+                        case .codebuddy: return "CodeBuddy"
+                        case .workbuddy: return "WorkBuddy"
                         }
                     }()
                     let accent: Color = sourceAccent(s)
@@ -1342,6 +1370,16 @@ struct UnifiedSessionsView: View {
                     AgentTabToggle(title: "Cursor", color: Color.agentCursor, isMonochrome: stripMonochrome, isOn: $unified.includeCursor)
                         .help("Show or hide Cursor sessions in the list (⌘8)")
                         .keyboardShortcut("8", modifiers: .command)
+                }
+
+                if codebuddyAgentEnabled {
+                    AgentTabToggle(title: "CodeBuddy", color: Color.agentCodeBuddy, isMonochrome: stripMonochrome, isOn: $unified.includeCodebuddy)
+                        .help("Show or hide CodeBuddy sessions in the list")
+                }
+
+                if workbuddyAgentEnabled {
+                    AgentTabToggle(title: "WorkBuddy", color: Color.agentWorkBuddy, isMonochrome: stripMonochrome, isOn: $unified.includeWorkbuddy)
+                        .help("Show or hide WorkBuddy sessions in the list")
                 }
             }
             .controlSize(.small)
@@ -1812,6 +1850,10 @@ struct UnifiedSessionsView: View {
             if !unified.includeOpenClaw { unified.includeOpenClaw = true }
         case .cursor:
             if !unified.includeCursor { unified.includeCursor = true }
+        case .codebuddy:
+            if !unified.includeCodebuddy { unified.includeCodebuddy = true }
+        case .workbuddy:
+            if !unified.includeWorkbuddy { unified.includeWorkbuddy = true }
         }
     }
 
@@ -2029,6 +2071,8 @@ struct UnifiedSessionsView: View {
         case .droid: label = "Droid"
         case .openclaw: label = "OpenClaw"
         case .cursor: label = "Cursor"
+        case .codebuddy: label = "CodeBuddy"
+        case .workbuddy: label = "WorkBuddy"
         }
         let isSubagentRow = (hierarchyRowMeta[session.id]?.depth ?? 0) > 0
         return HStack(spacing: 6) {
@@ -2414,12 +2458,14 @@ struct UnifiedSessionsView: View {
 	                                includeDroid: unified.includeDroid && droidAgentEnabled,
 	                                includeOpenClaw: unified.includeOpenClaw && openClawAgentEnabled,
 	                                includeCursor: unified.includeCursor && cursorAgentEnabled,
+	                                includeCodebuddy: unified.includeCodebuddy && codebuddyAgentEnabled,
+	                                includeWorkbuddy: unified.includeWorkbuddy && workbuddyAgentEnabled,
 	                                enableDeepScan: searchCoordinator.deepScanEnabled,
 	                                all: unified.allSessions)
 	    }
 
     private func flashAgentEnablementNoticeIfNeeded() {
-        let anyDisabled = !(codexAgentEnabled && claudeAgentEnabled && geminiAgentEnabled && openCodeAgentEnabled && hermesAgentEnabled && copilotAgentEnabled && droidAgentEnabled && openClawAgentEnabled && cursorAgentEnabled)
+        let anyDisabled = !(codexAgentEnabled && claudeAgentEnabled && geminiAgentEnabled && openCodeAgentEnabled && hermesAgentEnabled && copilotAgentEnabled && droidAgentEnabled && openClawAgentEnabled && cursorAgentEnabled && codebuddyAgentEnabled && workbuddyAgentEnabled)
         guard anyDisabled else {
             withAnimation { showAgentEnablementNotice = false }
             return
@@ -2442,6 +2488,8 @@ struct UnifiedSessionsView: View {
         case .droid: return Color.agentDroid
         case .openclaw: return Color.agentOpenClaw
         case .cursor: return Color(red: 0.20, green: 0.60, blue: 0.70)
+        case .codebuddy: return Color.agentCodeBuddy
+        case .workbuddy: return Color.agentWorkBuddy
         }
     }
 
@@ -2828,6 +2876,8 @@ private struct TranscriptHostView: View {
     let droidIndexer: DroidSessionIndexer
     let openclawIndexer: OpenClawSessionIndexer
     let cursorIndexer: CursorSessionIndexer
+    let codebuddyIndexer: BuddySessionIndexer
+    let workbuddyIndexer: BuddySessionIndexer
 
     var body: some View {
         ZStack { // keep one stable container to avoid split reset
@@ -2850,6 +2900,10 @@ private struct TranscriptHostView: View {
                 .opacity(kind == .openclaw ? 1 : 0)
             CursorTranscriptView(indexer: cursorIndexer, sessionID: selection)
                 .opacity(kind == .cursor ? 1 : 0)
+            BuddyTranscriptView(indexer: codebuddyIndexer, sessionID: selection)
+                .opacity(kind == .codebuddy ? 1 : 0)
+            BuddyTranscriptView(indexer: workbuddyIndexer, sessionID: selection)
+                .opacity(kind == .workbuddy ? 1 : 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .clipped()
@@ -3116,6 +3170,8 @@ private struct UnifiedSearchFiltersView: View {
                      includeDroid: unified.includeDroid,
                      includeOpenClaw: unified.includeOpenClaw,
                      includeCursor: unified.includeCursor,
+                     includeCodebuddy: unified.includeCodebuddy,
+                     includeWorkbuddy: unified.includeWorkbuddy,
                      enableDeepScan: deepScan,
                      all: unified.allSessions)
     }
@@ -3149,6 +3205,8 @@ private struct UnifiedSearchFiltersView: View {
                          includeDroid: unified.includeDroid,
                          includeOpenClaw: unified.includeOpenClaw,
                          includeCursor: unified.includeCursor,
+                         includeCodebuddy: unified.includeCodebuddy,
+                         includeWorkbuddy: unified.includeWorkbuddy,
                          enableDeepScan: false,
                          all: unified.allSessions)
         }

--- a/AgentSessionsTests/BuddySessionDiscoveryTests.swift
+++ b/AgentSessionsTests/BuddySessionDiscoveryTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import AgentSessions
+
+final class BuddySessionDiscoveryTests: XCTestCase {
+
+    func testDiscoverSessionFiles_findsJsonlUnderArbitraryTree() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("buddy-disc-\(UUID().uuidString)", isDirectory: true)
+        let codeRoot = base.appendingPathComponent("codebuddy-root", isDirectory: true)
+        let sessionDir = codeRoot.appendingPathComponent("encoded-path", isDirectory: true)
+        try fm.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        let sessionURL = sessionDir.appendingPathComponent("session-a.jsonl")
+        try Data(#"{"type":"message","timestamp":1,"role":"user","content":"x"}"#.utf8).write(to: sessionURL)
+
+        let discovery = BuddySessionDiscovery(
+            codebuddyProjectsRoot: codeRoot.path,
+            workbuddyProjectsRoot: base.appendingPathComponent("empty-work").path
+        )
+        try fm.createDirectory(at: base.appendingPathComponent("empty-work"), withIntermediateDirectories: true)
+
+        let found = discovery.discoverSessionFiles()
+        defer { try? fm.removeItem(at: base) }
+
+        XCTAssertEqual(found.count, 1)
+        XCTAssertEqual(found.first?.lastPathComponent, "session-a.jsonl")
+    }
+
+    func testDiscoverSessionFiles_skipsToolResultsDirectory() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("buddy-disc-tr-\(UUID().uuidString)", isDirectory: true)
+        let codeRoot = base.appendingPathComponent("cb", isDirectory: true)
+        let toolResults = codeRoot.appendingPathComponent("proj/tool-results", isDirectory: true)
+        let goodDir = codeRoot.appendingPathComponent("proj/sessions", isDirectory: true)
+        try fm.createDirectory(at: toolResults, withIntermediateDirectories: true)
+        try fm.createDirectory(at: goodDir, withIntermediateDirectories: true)
+        try Data(#"{"type":"message","timestamp":1,"role":"user","content":"keep"}"#.utf8).write(to: goodDir.appendingPathComponent("good.jsonl"))
+        try Data(#"{"type":"message","timestamp":1,"role":"user","content":"skip"}"#.utf8).write(to: toolResults.appendingPathComponent("noise.jsonl"))
+
+        let discovery = BuddySessionDiscovery(
+            codebuddyProjectsRoot: codeRoot.path,
+            workbuddyProjectsRoot: base.appendingPathComponent("wb").path
+        )
+        try fm.createDirectory(at: base.appendingPathComponent("wb"), withIntermediateDirectories: true)
+
+        let found = discovery.discoverSessionFiles()
+        defer { try? fm.removeItem(at: base) }
+
+        XCTAssertEqual(found.count, 1)
+        let p = found.first?.path ?? ""
+        XCTAssertFalse(p.contains("tool-results"), "tool-results JSONL must be skipped: \(p)")
+    }
+
+    func testProjectRoots_withOverrides_returnsBothURLs() {
+        let d = BuddySessionDiscovery(codebuddyProjectsRoot: "/tmp/cb", workbuddyProjectsRoot: "/tmp/wb")
+        let roots = d.projectRoots()
+        XCTAssertEqual(roots.count, 2)
+        XCTAssertEqual(roots[0].path, "/tmp/cb")
+        XCTAssertEqual(roots[1].path, "/tmp/wb")
+    }
+}

--- a/AgentSessionsTests/BuddySessionParserTests.swift
+++ b/AgentSessionsTests/BuddySessionParserTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+@testable import AgentSessions
+
+final class BuddySessionParserTests: XCTestCase {
+
+    private func writeTempJSONL(_ lines: [String]) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("buddy_test_\(UUID().uuidString).jsonl")
+        let content = lines.joined(separator: "\n") + "\n"
+        try Data(content.utf8).write(to: url)
+        return url
+    }
+
+    // MARK: - Preview (lightweight)
+
+    func testParseFile_preview_countsUserAssistantAndTools() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"sess-preview-1","timestamp":1700000000000,"cwd":"/tmp/sample-repo","role":"user","content":"Ship the feature"}"#,
+            #"{"type":"message","sessionId":"sess-preview-1","timestamp":1700000001000,"cwd":"/tmp/sample-repo","role":"assistant","content":"On it."}"#,
+            #"{"type":"function_call","sessionId":"sess-preview-1","timestamp":1700000002000,"name":"read_file","arguments":"{\"path\":\"README.md\"}"}"#,
+            #"{"type":"function_call_result","sessionId":"sess-preview-1","timestamp":1700000003000,"name":"read_file","output":"Title line"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let preview = CodebuddySessionParser.parseFile(at: url) else {
+            return XCTFail("preview parse returned nil")
+        }
+        XCTAssertEqual(preview.source, .codebuddy)
+        XCTAssertEqual(preview.events.count, 0)
+        XCTAssertEqual(preview.codexInternalSessionIDHint, "sess-preview-1")
+        XCTAssertEqual(preview.cwd, "/tmp/sample-repo")
+        XCTAssertEqual(preview.repoName, "sample-repo")
+        XCTAssertEqual(preview.lightweightTitle, "Ship the feature")
+        XCTAssertEqual(preview.lightweightCommands, 1)
+        XCTAssertGreaterThanOrEqual(preview.eventCount, 3)
+    }
+
+    func testParseFile_preview_extractsModelFromProviderData() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"m1","timestamp":1700000000000,"cwd":"/tmp","role":"user","content":"Hi","providerData":{"model":"buddy-test-model"}}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let preview = CodebuddySessionParser.parseFile(at: url) else {
+            return XCTFail("preview parse returned nil")
+        }
+        XCTAssertEqual(preview.model, "buddy-test-model")
+    }
+
+    func testParseFile_returnsNilWhenNoUserOrAssistantMessages() throws {
+        let lines = [
+            #"{"type":"function_call","sessionId":"x","timestamp":1700000000000,"name":"noop","arguments":"{}"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertNil(CodebuddySessionParser.parseFile(at: url))
+    }
+
+    func testParseFile_previewScansPastLongMetaPreamble() throws {
+        var lines = (0..<140).map { idx in
+            #"{"type":"file-history-snapshot","sessionId":"long-meta","timestamp":1700000000\#(String(format: "%03d", idx))}"#
+        }
+        lines.append(#"{"type":"message","sessionId":"long-meta","timestamp":1700000002000,"cwd":"/tmp/long-meta","role":"user","content":"Actual request"}"#)
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let preview = CodebuddySessionParser.parseFile(at: url) else {
+            return XCTFail("preview parse should continue past meta preamble")
+        }
+        XCTAssertEqual(preview.lightweightTitle, "Actual request")
+        XCTAssertEqual(preview.codexInternalSessionIDHint, "long-meta")
+    }
+
+    func testParseFile_respectsForcedID() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"ignored","timestamp":1700000000000,"cwd":"/tmp","role":"user","content":"x"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let preview = CodebuddySessionParser.parseFile(at: url, forcedID: "forced-buddy-id") else {
+            return XCTFail("preview parse returned nil")
+        }
+        XCTAssertEqual(preview.id, "forced-buddy-id")
+    }
+
+    // MARK: - Full parse
+
+    func testParseFileFull_mapsMessagesAndToolEvents() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"full-1","timestamp":1700000000000,"cwd":"/tmp/ws","role":"user","content":"Run checks"}"#,
+            #"{"type":"message","sessionId":"full-1","timestamp":1700000001000,"cwd":"/tmp/ws","role":"assistant","content":"Running."}"#,
+            #"{"type":"function_call","sessionId":"full-1","timestamp":1700000002000,"name":"bash","arguments":"{\"cmd\":\"true\"}"}"#,
+            #"{"type":"function_call_result","sessionId":"full-1","timestamp":1700000003000,"name":"bash","output":"ok"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let session = CodebuddySessionParser.parseFileFull(at: url) else {
+            return XCTFail("full parse returned nil")
+        }
+        XCTAssertEqual(session.source, .codebuddy)
+        XCTAssertEqual(session.events.filter { $0.kind == .user }.count, 1)
+        XCTAssertEqual(session.events.filter { $0.kind == .assistant }.count, 1)
+        XCTAssertEqual(session.events.filter { $0.kind == .tool_call }.count, 1)
+        XCTAssertEqual(session.events.filter { $0.kind == .tool_result }.count, 1)
+
+        let call = session.events.first(where: { $0.kind == .tool_call })
+        XCTAssertEqual(call?.toolName, "bash")
+        XCTAssertTrue((call?.toolInput ?? "").contains("true"))
+
+        let result = session.events.first(where: { $0.kind == .tool_result })
+        XCTAssertEqual(result?.toolName, "bash")
+        XCTAssertEqual(result?.toolOutput, "ok")
+    }
+
+    func testParseFileFull_reasoningLine_isMeta() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"r1","timestamp":1700000000000,"cwd":"/tmp","role":"user","content":"Think"}"#,
+            #"{"type":"reasoning","sessionId":"r1","timestamp":1700000001000,"rawContent":"step a"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let session = CodebuddySessionParser.parseFileFull(at: url) else {
+            return XCTFail("full parse returned nil")
+        }
+        let meta = session.events.filter { $0.kind == .meta }
+        XCTAssertTrue(meta.contains(where: { ($0.text ?? "").contains("[reasoning]") }))
+    }
+
+    func testParseFileFull_topicLine_isMeta() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"t1","timestamp":1700000000000,"cwd":"/tmp","role":"user","content":"Go"}"#,
+            #"{"type":"topic","sessionId":"t1","timestamp":1700000001000,"topic":"refactor-auth"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let session = CodebuddySessionParser.parseFileFull(at: url) else {
+            return XCTFail("full parse returned nil")
+        }
+        XCTAssertTrue(session.events.contains(where: { ($0.text ?? "").contains("[topic]") && ($0.text ?? "").contains("refactor-auth") }))
+    }
+
+    func testParseFileFull_transcriptBuildDoesNotCrash() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"tb1","timestamp":1700000000000,"cwd":"/tmp","role":"user","content":"Hello"}"#,
+            #"{"type":"message","sessionId":"tb1","timestamp":1700000001000,"cwd":"/tmp","role":"assistant","content":"World"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let session = CodebuddySessionParser.parseFileFull(at: url) else {
+            return XCTFail("full parse returned nil")
+        }
+        let tf: TranscriptFilters = .current(showTimestamps: false, showMeta: true)
+        let text = SessionTranscriptBuilder.buildPlainTerminalTranscript(session: session, filters: tf, mode: .normal)
+        XCTAssertFalse(text.isEmpty)
+        XCTAssertTrue(text.contains("Hello") || text.contains("World"))
+    }
+
+    func testWorkbuddyParseFile_preview_usesWorkbuddySource() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"wb-1","timestamp":1700000000000,"cwd":"/tmp/wb","role":"user","content":"IDE task"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let preview = WorkbuddySessionParser.parseFile(at: url) else {
+            return XCTFail("preview parse returned nil")
+        }
+        XCTAssertEqual(preview.source, .workbuddy)
+    }
+
+    func testBuddySessionMatchesFilterEngineFreeText() throws {
+        let lines = [
+            #"{"type":"message","sessionId":"fe1","timestamp":1700000000000,"cwd":"/tmp","role":"user","content":"UniqueBuddyTokenXYZ"}"#,
+            #"{"type":"message","sessionId":"fe1","timestamp":1700000001000,"cwd":"/tmp","role":"assistant","content":"reply"}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let session = CodebuddySessionParser.parseFileFull(at: url) else {
+            return XCTFail("full parse returned nil")
+        }
+        let filters = Filters(
+            query: "UniqueBuddyTokenXYZ",
+            dateFrom: nil,
+            dateTo: nil,
+            model: nil,
+            kinds: Set(SessionEventKind.allCases),
+            repoName: nil,
+            pathContains: nil
+        )
+        let hits = FilterEngine.filterSessions([session], filters: filters, transcriptCache: nil, allowTranscriptGeneration: false)
+        XCTAssertEqual(hits.count, 1)
+        XCTAssertEqual(hits.first?.id, session.id)
+    }
+}

--- a/AgentSessionsTests/CodexActiveSessionsRegistryTests.swift
+++ b/AgentSessionsTests/CodexActiveSessionsRegistryTests.swift
@@ -3391,6 +3391,8 @@ final class CodexActiveSessionsRegistryTests: XCTestCase {
             droidList: [],
             openclawList: [],
             cursorList: [],
+            codebuddyList: [],
+            workbuddyList: [],
             favoritesSnapshot: UnifiedSessionIndexer.FavoritesStore.Snapshot(legacyIDs: [], scopedKeys: [favoriteKey]),
             favoritesVersion: 1,
             enablement: UnifiedSessionIndexer.AgentEnablementSnapshot(
@@ -3402,7 +3404,9 @@ final class CodexActiveSessionsRegistryTests: XCTestCase {
                 copilot: false,
                 droid: false,
                 openClaw: false,
-                cursor: false
+                cursor: false,
+                codebuddy: false,
+                workbuddy: false
             )
         )
 
@@ -3425,6 +3429,8 @@ final class CodexActiveSessionsRegistryTests: XCTestCase {
             droidList: [],
             openclawList: [],
             cursorList: [],
+            codebuddyList: [],
+            workbuddyList: [],
             favoritesSnapshot: UnifiedSessionIndexer.FavoritesStore.Snapshot(legacyIDs: [], scopedKeys: []),
             favoritesVersion: 3,
             enablement: UnifiedSessionIndexer.AgentEnablementSnapshot(
@@ -3436,7 +3442,9 @@ final class CodexActiveSessionsRegistryTests: XCTestCase {
                 copilot: false,
                 droid: false,
                 openClaw: false,
-                cursor: false
+                cursor: false,
+                codebuddy: false,
+                workbuddy: false
             )
         )
 

--- a/AgentSessionsTests/NewProviderDiscoverabilityTests.swift
+++ b/AgentSessionsTests/NewProviderDiscoverabilityTests.swift
@@ -41,6 +41,8 @@ final class NewProviderDiscoverabilityTests: XCTestCase {
     func testEnablementKeyReturnsCorrectKeyForEachSource() {
         XCTAssertEqual(AgentEnablement.enablementKey(for: .codex), "AgentEnabledCodex")
         XCTAssertEqual(AgentEnablement.enablementKey(for: .cursor), "AgentEnabledCursor")
+        XCTAssertEqual(AgentEnablement.enablementKey(for: .codebuddy), "AgentEnabledCodebuddy")
+        XCTAssertEqual(AgentEnablement.enablementKey(for: .workbuddy), "AgentEnabledWorkbuddy")
     }
 
     func testMigrateKnownAvailableProviders_populatesFromExplicitPreferences() {
@@ -58,6 +60,33 @@ final class NewProviderDiscoverabilityTests: XCTestCase {
         XCTAssertTrue(known.contains("codex"))
         XCTAssertTrue(known.contains("claude"))
         XCTAssertFalse(known.contains("cursor"), "Cursor has no explicit pref — should not be in known set")
+    }
+
+    func testMigrateKnownAvailableProviders_includesCodebuddyWhenExplicitlyEnabled() {
+        let suite = "test.migrate.codebuddy.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        defaults.set(true, forKey: AgentEnablement.enablementKey(for: .codebuddy))
+        AgentEnablement.migrateKnownAvailableProvidersIfNeeded(defaults: defaults)
+
+        let known = defaults.stringArray(forKey: PreferencesKey.Agents.knownAvailableProviders) ?? []
+        XCTAssertTrue(known.contains("codebuddy"))
+    }
+
+    func testNewlyAvailableProviders_includesWorkbuddyWhenNotInKnownSet() {
+        let suite = "test.detect.workbuddy.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        defaults.set(["codex"], forKey: PreferencesKey.Agents.knownAvailableProviders)
+
+        let candidates = AgentEnablement.newlyAvailableProviders(
+            availableSources: [.codex, .workbuddy],
+            defaults: defaults
+        )
+
+        XCTAssertEqual(candidates, [.workbuddy])
     }
 
     func testMigrateKnownAvailableProviders_isNoOpOnSubsequentRuns() {

--- a/AgentSessionsTests/SearchCoordinatorTests.swift
+++ b/AgentSessionsTests/SearchCoordinatorTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import AgentSessions
+
+final class SearchCoordinatorTests: XCTestCase {
+    func testFTSEligibleSources_excludesSourcesWithoutFTSIndex() {
+        XCTAssertEqual(
+            SearchCoordinator.ftsEligibleSources(from: [.cursor, .codebuddy, .workbuddy]),
+            []
+        )
+
+        XCTAssertEqual(
+            SearchCoordinator.ftsEligibleSources(from: [.codex, .codebuddy, .workbuddy]),
+            [.codex]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add CodeBuddy and WorkBuddy session discovery, parsing, indexing, transcript rendering, and source filtering.
- Wire the new providers through app startup, unified sessions, onboarding, preferences, archive/starred compatibility, colors, and labels.
- Preserve legacy Buddy preferences/starred data and add regressions for parser discovery and Buddy search behavior.

## Test plan
- xcodebuild test -project AgentSessions.xcodeproj -scheme AgentSessions -derivedDataPath /tmp/AgentSessionsReviewShipTests -only-testing:AgentSessionsTests/BuddySessionParserTests -only-testing:AgentSessionsTests/BuddySessionDiscoveryTests -only-testing:AgentSessionsTests/SearchCoordinatorTests -only-testing:AgentSessionsTests/NewProviderDiscoverabilityTests -destination 'platform=macOS,arch=arm64'
- xcodebuild build -project AgentSessions.xcodeproj -scheme AgentSessions -configuration Debug -derivedDataPath /tmp/AgentSessionsReviewShipBuild -destination 'platform=macOS,arch=arm64'

Made with [Cursor](https://cursor.com)