### PR TITLE
fix: harden Buddy session format support

### DIFF
--- a/AgentSessions/Model/Session.swift
+++ b/AgentSessions/Model/Session.swift
@@ -509,7 +509,7 @@ public struct Session: Identifiable, Equatable, Codable, Sendable {
     public var cwd: String? {
         // Providers that persist cwd as lightweight metadata should keep using it
         // after full parse as well; transcript event scraping is not authoritative.
-        if (source == .gemini || source == .opencode || source == .copilot || source == .openclaw || source == .hermes),
+        if (source == .gemini || source == .opencode || source == .copilot || source == .openclaw || source == .hermes || source == .codebuddy || source == .workbuddy),
            let lightCwd = lightweightCwd, !lightCwd.isEmpty {
             return lightCwd
         }

--- a/AgentSessions/Search/SearchCoordinator.swift
+++ b/AgentSessions/Search/SearchCoordinator.swift
@@ -350,9 +350,10 @@ final class SearchCoordinator: ObservableObject, @unchecked Sendable {
                     // content-searchable while their FTS rows are still missing or warming.
                     let smallSearchThreshold = FeatureFlags.searchSmallSizeBytes
                     let unindexedCandidates = candidates.filter {
-                        !indexedIDs.contains($0.id)
+                        let size = Self.sizeBytes(for: $0)
+                        return !indexedIDs.contains($0.id)
                             && !seen.contains($0.id)
-                            && (enableDeepScan || Self.ftsEligibleSources(from: [$0.source]).isEmpty || Self.sizeBytes(for: $0) < smallSearchThreshold)
+                            && (enableDeepScan || size < smallSearchThreshold)
                     }
                     let deepCandidates = deepEnabled
                         ? candidates.filter { indexedIDs.contains($0.id) && !seen.contains($0.id) && Self.shouldDeepScan(session: $0) }

--- a/AgentSessions/Services/BuddySessionParser.swift
+++ b/AgentSessions/Services/BuddySessionParser.swift
@@ -39,26 +39,21 @@ enum BuddyJSONLTranscriptParsing {
                       let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                     return true
                 }
-                if sessionHint == nil, let sid = obj["sessionId"] as? String, !sid.isEmpty {
-                    sessionHint = sid
-                }
-                if cwd == nil, let c = obj["cwd"] as? String, !c.isEmpty {
-                    cwd = c
-                }
+                if sessionHint == nil { sessionHint = extractSessionID(from: obj) }
+                if cwd == nil { cwd = extractCWD(from: obj) }
                 if model == nil { model = extractModel(from: obj) }
                 if let ts = extractTimestamp(from: obj) {
                     if tmin == nil || ts < tmin! { tmin = ts }
                     if tmax == nil || ts > tmax! { tmax = ts }
                 }
-                let type = (obj["type"] as? String)?.lowercased() ?? ""
-                switch type {
-                case "message":
-                    let role = (obj["role"] as? String)?.lowercased() ?? ""
-                    if role == "user" || role == "assistant" { messageCount += 1 }
-                    if firstUser == nil, role == "user", let t = stringifyContent(obj["content"]), !t.isEmpty {
+                let kind = eventKind(from: obj)
+                switch kind {
+                case .user, .assistant:
+                    messageCount += 1
+                    if firstUser == nil, kind == .user, let t = extractText(from: obj), !t.isEmpty {
                         firstUser = truncateTitle(t)
                     }
-                case "function_call":
+                case .tool_call:
                     toolCount += 1
                 default:
                     break
@@ -72,6 +67,7 @@ enum BuddyJSONLTranscriptParsing {
         guard messageCount > 0 else { return nil }
 
         let sid = forcedID ?? sha256(path: url.path)
+        if cwd == nil { cwd = inferCWDBestEffort(from: url) }
         let repo = cwd.flatMap { URL(fileURLWithPath: $0).lastPathComponent }
 
         return Session(
@@ -119,12 +115,8 @@ enum BuddyJSONLTranscriptParsing {
                       let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                     return
                 }
-                if sessionHint == nil, let sid = obj["sessionId"] as? String, !sid.isEmpty {
-                    sessionHint = sid
-                }
-                if cwd == nil, let c = obj["cwd"] as? String, !c.isEmpty {
-                    cwd = c
-                }
+                if sessionHint == nil { sessionHint = extractSessionID(from: obj) }
+                if cwd == nil { cwd = extractCWD(from: obj) }
                 if model == nil { model = extractModel(from: obj) }
                 if let ts = extractTimestamp(from: obj) {
                     if tmin == nil || ts < tmin! { tmin = ts }
@@ -138,6 +130,7 @@ enum BuddyJSONLTranscriptParsing {
         }
 
         let sid = forcedID ?? sha256(path: url.path)
+        if cwd == nil { cwd = inferCWDBestEffort(from: url) }
         let repo = cwd.flatMap { URL(fileURLWithPath: $0).lastPathComponent }
         let nonMeta = events.filter { $0.kind != .meta }.count
         let isHousekeeping = Session.computeIsHousekeeping(source: source, events: events)
@@ -171,27 +164,12 @@ enum BuddyJSONLTranscriptParsing {
     private static func parseLineEvents(_ obj: [String: Any], baseEventID: String) -> [SessionEvent] {
         let rawJSON = rawJSONBase64(truncateLargeStrings(in: obj))
         let ts = extractTimestamp(from: obj)
-        guard let typeRaw = obj["type"] as? String else {
-            return [metaEvent(id: baseEventID, ts: ts, text: "(missing type)", raw: rawJSON)]
-        }
-        let type = typeRaw.lowercased()
-        switch type {
-        case "message":
-            let roleRaw = (obj["role"] as? String)?.lowercased() ?? "assistant"
-            let role: String
-            let kind: SessionEventKind
-            switch roleRaw {
-            case "user", "human":
-                role = "user"; kind = .user
-            case "assistant", "model":
-                role = "assistant"; kind = .assistant
-            case "system":
-                role = "system"; kind = .meta
-            default:
-                role = roleRaw
-                kind = .assistant
-            }
-            let text = stringifyContent(obj["content"])
+        let type = extractType(from: obj)
+        let kind = eventKind(from: obj)
+        switch kind {
+        case .user, .assistant:
+            let role = normalizedRole(from: obj) ?? (kind == .user ? "user" : "assistant")
+            let text = extractText(from: obj)
             return [
                 SessionEvent(
                     id: baseEventID,
@@ -202,15 +180,15 @@ enum BuddyJSONLTranscriptParsing {
                     toolName: nil,
                     toolInput: nil,
                     toolOutput: nil,
-                    messageID: obj["id"] as? String,
-                    parentID: obj["parentId"] as? String,
+                    messageID: extractMessageID(from: obj),
+                    parentID: extractParentID(from: obj),
                     isDelta: false,
                     rawJSON: rawJSON
                 )
             ]
-        case "function_call":
-            let name = (obj["name"] as? String) ?? "tool"
-            let input = stringifyJSONValue(obj["arguments"]) ?? stringifyJSONValue(obj["message"])
+        case .tool_call:
+            let name = extractToolName(from: obj) ?? "tool"
+            let input = extractToolInput(from: obj)
             return [
                 SessionEvent(
                     id: baseEventID,
@@ -221,15 +199,15 @@ enum BuddyJSONLTranscriptParsing {
                     toolName: name,
                     toolInput: input,
                     toolOutput: nil,
-                    messageID: obj["id"] as? String,
-                    parentID: obj["parentId"] as? String,
+                    messageID: extractMessageID(from: obj),
+                    parentID: extractParentID(from: obj),
                     isDelta: false,
                     rawJSON: rawJSON
                 )
             ]
-        case "function_call_result":
-            let name = (obj["name"] as? String) ?? "tool"
-            let output = stringifyJSONValue(obj["output"]) ?? stringifyJSONValue(obj["message"])
+        case .tool_result:
+            let name = extractToolName(from: obj) ?? "tool"
+            let output = extractToolOutput(from: obj)
             return [
                 SessionEvent(
                     id: baseEventID,
@@ -240,13 +218,13 @@ enum BuddyJSONLTranscriptParsing {
                     toolName: name,
                     toolInput: nil,
                     toolOutput: output,
-                    messageID: obj["id"] as? String,
-                    parentID: obj["parentId"] as? String,
+                    messageID: extractMessageID(from: obj),
+                    parentID: extractParentID(from: obj),
                     isDelta: false,
                     rawJSON: rawJSON
                 )
             ]
-        case "reasoning":
+        case .meta where type == "reasoning":
             let body = (obj["rawContent"] as? String) ?? stringifyContent(obj["content"])
             return [
                 SessionEvent(
@@ -258,39 +236,38 @@ enum BuddyJSONLTranscriptParsing {
                     toolName: nil,
                     toolInput: nil,
                     toolOutput: nil,
-                    messageID: obj["id"] as? String,
-                    parentID: obj["parentId"] as? String,
+                    messageID: extractMessageID(from: obj),
+                    parentID: extractParentID(from: obj),
                     isDelta: false,
                     rawJSON: rawJSON
                 )
             ]
-        case "topic", "file-history-snapshot":
+        case .meta where type == "topic" || type == "file-history-snapshot":
             let summary: String = {
                 if type == "topic", let t = obj["topic"] as? String { return "[topic] \(t)" }
                 return "[\(type)]"
             }()
             return [metaEvent(id: baseEventID, ts: ts, text: summary, raw: rawJSON)]
-        default:
-            let mapped = SessionEventKind.from(role: nil, type: type)
-            if mapped == .meta {
-                return [metaEvent(id: baseEventID, ts: ts, text: "[\(type)]", raw: rawJSON)]
-            }
+        case .error:
             return [
                 SessionEvent(
                     id: baseEventID,
                     timestamp: ts,
-                    kind: mapped,
-                    role: "meta",
-                    text: nil,
+                    kind: .error,
+                    role: normalizedRole(from: obj) ?? "error",
+                    text: extractText(from: obj) ?? extractToolOutput(from: obj),
                     toolName: nil,
                     toolInput: nil,
                     toolOutput: nil,
-                    messageID: nil,
-                    parentID: nil,
+                    messageID: extractMessageID(from: obj),
+                    parentID: extractParentID(from: obj),
                     isDelta: false,
                     rawJSON: rawJSON
                 )
             ]
+        default:
+            let label = type.isEmpty ? "(missing type)" : "[\(type)]"
+            return [metaEvent(id: baseEventID, ts: ts, text: label, raw: rawJSON)]
         }
     }
 
@@ -314,34 +291,187 @@ enum BuddyJSONLTranscriptParsing {
     // MARK: - Helpers
 
     private static func extractTimestamp(from obj: [String: Any]) -> Date? {
-        if let n = obj["timestamp"] as? NSNumber {
-            return Date(timeIntervalSince1970: n.doubleValue / 1000.0)
-        }
-        if let i = obj["timestamp"] as? Int {
-            return Date(timeIntervalSince1970: Double(i) / 1000.0)
-        }
-        if let s = obj["timestamp"] as? String {
-            return ISO8601DateFormatter().date(from: s)
+        for key in ["timestamp", "createdAt", "created_at", "updatedAt", "updated_at", "time", "ts"] {
+            guard let value = obj[key] else { continue }
+            if let n = value as? NSNumber {
+                return dateFromEpoch(n.doubleValue)
+            }
+            if let s = value as? String {
+                if let numeric = Double(s) {
+                    return dateFromEpoch(numeric)
+                }
+                if let date = isoDate(s) {
+                    return date
+                }
+            }
         }
         return nil
     }
 
     private static func extractModel(from obj: [String: Any]) -> String? {
+        for key in ["model", "modelId", "model_id"] {
+            if let m = obj[key] as? String, !m.isEmpty { return m }
+        }
         if let pd = obj["providerData"] as? [String: Any] {
             if let m = pd["model"] as? String, !m.isEmpty { return m }
             if let m = pd["modelId"] as? String, !m.isEmpty { return m }
+            if let m = pd["model_id"] as? String, !m.isEmpty { return m }
         }
+        if let message = obj["message"] as? [String: Any] {
+            for key in ["model", "modelId", "model_id"] {
+                if let m = message[key] as? String, !m.isEmpty { return m }
+            }
+        }
+        if let metadata = obj["metadata"] as? [String: Any] {
+            for key in ["model", "modelId", "model_id"] {
+                if let m = metadata[key] as? String, !m.isEmpty { return m }
+            }
+        }
+        return nil
+    }
+
+    private static func eventKind(from obj: [String: Any]) -> SessionEventKind {
+        let type = extractType(from: obj)
+        let role = normalizedRole(from: obj)
+        if type == "assistant_message" { return .assistant }
+        if type == "user_message" { return .user }
+        if type == "message" || type == "chat.message" || type == "conversation.message" || type == "assistant_message" || type == "user_message" {
+            return SessionEventKind.from(role: role, type: nil)
+        }
+        let mapped = SessionEventKind.from(role: role, type: type)
+        if mapped != .meta { return mapped }
+        switch type {
+        case "user", "human":
+            return .user
+        case "assistant", "model":
+            return .assistant
+        default:
+            return mapped
+        }
+    }
+
+    private static func extractType(from obj: [String: Any]) -> String {
+        for key in ["type", "event", "eventType", "event_type", "kind"] {
+            if let s = obj[key] as? String, !s.isEmpty { return s.lowercased() }
+        }
+        return ""
+    }
+
+    private static func normalizedRole(from obj: [String: Any]) -> String? {
+        let role = firstString(in: obj, keys: ["role", "authorRole", "author_role", "sender", "speaker"])
+            ?? nestedString(in: obj, path: ["message", "role"])
+            ?? nestedString(in: obj, path: ["author", "role"])
+        guard let role else { return nil }
+        switch role.lowercased() {
+        case "human": return "user"
+        case "model": return "assistant"
+        default: return role.lowercased()
+        }
+    }
+
+    private static func extractSessionID(from obj: [String: Any]) -> String? {
+        let explicit = firstString(in: obj, keys: [
+            "sessionId", "session_id", "conversationId", "conversation_id",
+            "chatId", "chat_id", "threadId", "thread_id"
+        ])
+        if let explicit { return explicit }
+        if let nested = nestedString(in: obj, path: ["session", "id"])
+            ?? nestedString(in: obj, path: ["conversation", "id"])
+            ?? nestedString(in: obj, path: ["chat", "id"]) {
+            return nested
+        }
+        let type = extractType(from: obj)
+        if type.contains("session") || type.contains("conversation") || type == "metadata" {
+            return firstString(in: obj, keys: ["id"])
+        }
+        return nil
+    }
+
+    private static func extractCWD(from obj: [String: Any]) -> String? {
+        firstString(in: obj, keys: [
+            "cwd", "currentWorkingDirectory", "current_working_directory",
+            "workspace", "workspaceRoot", "workspace_root", "projectRoot", "project_root"
+        ])
+        ?? nestedString(in: obj, path: ["session", "cwd"])
+        ?? nestedString(in: obj, path: ["workspace", "path"])
+        ?? nestedString(in: obj, path: ["project", "path"])
+    }
+
+    private static func extractMessageID(from obj: [String: Any]) -> String? {
+        firstString(in: obj, keys: ["messageId", "message_id", "uuid", "id"])
+            ?? nestedString(in: obj, path: ["message", "id"])
+    }
+
+    private static func extractParentID(from obj: [String: Any]) -> String? {
+        firstString(in: obj, keys: ["parentId", "parent_id"])
+            ?? nestedString(in: obj, path: ["message", "parentId"])
+            ?? nestedString(in: obj, path: ["message", "parent_id"])
+    }
+
+    private static func extractText(from obj: [String: Any]) -> String? {
+        for key in ["content", "text", "rawContent", "raw_content", "delta", "summary"] {
+            if let text = stringifyContent(obj[key]), !text.isEmpty { return text }
+        }
+        if let message = obj["message"] as? [String: Any] {
+            for key in ["content", "text", "rawContent", "raw_content", "delta"] {
+                if let text = stringifyContent(message[key]), !text.isEmpty { return text }
+            }
+        }
+        if let parts = obj["parts"], let text = stringifyContent(parts), !text.isEmpty { return text }
+        return nil
+    }
+
+    private static func extractToolName(from obj: [String: Any]) -> String? {
+        firstString(in: obj, keys: ["name", "toolName", "tool_name", "functionName", "function_name"])
+            ?? nestedString(in: obj, path: ["tool", "name"])
+            ?? nestedString(in: obj, path: ["function", "name"])
+            ?? nestedString(in: obj, path: ["message", "name"])
+    }
+
+    private static func extractToolInput(from obj: [String: Any]) -> String? {
+        for key in ["arguments", "args", "input", "parameters", "params", "toolInput", "tool_input"] {
+            if let value = stringifyJSONValue(obj[key]) { return value }
+        }
+        if let message = obj["message"] as? [String: Any] {
+            for key in ["arguments", "args", "input", "parameters", "params", "content"] {
+                if let value = stringifyJSONValue(message[key]) { return value }
+            }
+        }
+        return nil
+    }
+
+    private static func extractToolOutput(from obj: [String: Any]) -> String? {
+        for key in ["output", "result", "toolOutput", "tool_output", "content", "text"] {
+            if let value = stringifyJSONValue(obj[key]) { return value }
+        }
+        if let message = obj["message"] as? [String: Any] {
+            for key in ["output", "result", "content", "text"] {
+                if let value = stringifyJSONValue(message[key]) { return value }
+            }
+        }
+        if let value = stringifyJSONValue(obj["message"]) { return value }
         return nil
     }
 
     private static func stringifyContent(_ value: Any?) -> String? {
         if let s = value as? String { return s }
+        if let d = value as? [String: Any] {
+            for key in ["text", "content", "value", "input", "output"] {
+                if let text = stringifyContent(d[key]), !text.isEmpty { return text }
+            }
+            if let message = d["message"] as? [String: Any],
+               let text = stringifyContent(message["content"]), !text.isEmpty {
+                return text
+            }
+            return stringifyJSONValue(d)
+        }
         if let arr = value as? [Any] {
             var parts: [String] = []
             for item in arr {
                 if let d = item as? [String: Any] {
                     if let t = d["text"] as? String { parts.append(t); continue }
                     if let t = d["content"] as? String { parts.append(t); continue }
+                    if let t = nestedString(in: d, path: ["text", "value"]) { parts.append(t); continue }
                     if let sub = stringifyJSONValue(d) { parts.append(sub) }
                 } else if let s = item as? String {
                     parts.append(s)
@@ -351,6 +481,112 @@ enum BuddyJSONLTranscriptParsing {
             return joined.isEmpty ? nil : joined
         }
         return stringifyJSONValue(value)
+    }
+
+    private static func dateFromEpoch(_ raw: Double) -> Date {
+        let seconds: Double
+        let magnitude = abs(raw)
+        if magnitude > 1_000_000_000_000_000_000 {
+            seconds = raw / 1_000_000_000
+        } else if magnitude > 1_000_000_000_000_000 {
+            seconds = raw / 1_000_000
+        } else if magnitude > 10_000_000_000 {
+            seconds = raw / 1_000
+        } else {
+            seconds = raw
+        }
+        return Date(timeIntervalSince1970: seconds)
+    }
+
+    private static func isoDate(_ value: String) -> Date? {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFractional.date(from: value) { return date }
+        let standard = ISO8601DateFormatter()
+        standard.formatOptions = [.withInternetDateTime]
+        return standard.date(from: value)
+    }
+
+    private static func firstString(in obj: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let s = obj[key] as? String {
+                let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+            if let n = obj[key] as? NSNumber { return n.stringValue }
+        }
+        return nil
+    }
+
+    private static func nestedString(in obj: [String: Any], path: [String]) -> String? {
+        var current: Any? = obj
+        for key in path {
+            guard let dict = current as? [String: Any] else { return nil }
+            current = dict[key]
+        }
+        if let s = current as? String {
+            let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        if let n = current as? NSNumber { return n.stringValue }
+        return nil
+    }
+
+    private static func inferCWDBestEffort(from url: URL) -> String? {
+        guard let projectName = extractProjectDirName(from: url) else { return nil }
+        if let decoded = percentOrBase64DecodedPath(projectName) { return decoded }
+        return inferHyphenEncodedPath(projectName)
+    }
+
+    private static func extractProjectDirName(from url: URL) -> String? {
+        let components = url.pathComponents
+        for (i, component) in components.enumerated() where component == "projects" {
+            let next = i + 1
+            guard next < components.count else { continue }
+            let projectDir = components[next]
+            if projectDir == "projects" || projectDir == "tool-results" || projectDir.isEmpty { return nil }
+            return projectDir
+        }
+        return nil
+    }
+
+    private static func percentOrBase64DecodedPath(_ projectName: String) -> String? {
+        if let decoded = projectName.removingPercentEncoding, decoded.hasPrefix("/") {
+            return decoded
+        }
+        let urlBase64 = projectName.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        let padded = urlBase64.padding(toLength: ((urlBase64.count + 3) / 4) * 4, withPad: "=", startingAt: 0)
+        if let data = Data(base64Encoded: padded),
+           let decoded = String(data: data, encoding: .utf8),
+           decoded.hasPrefix("/") {
+            return decoded
+        }
+        return nil
+    }
+
+    private static func inferHyphenEncodedPath(_ projectName: String) -> String? {
+        let segments = projectName.components(separatedBy: "-")
+        guard !segments.isEmpty else { return nil }
+
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        var resolvedPrefix = ""
+        var currentComponent = segments[0]
+        var i = 1
+
+        while i < segments.count {
+            let candidateDir = resolvedPrefix + "/" + currentComponent
+            if fm.fileExists(atPath: candidateDir, isDirectory: &isDir), isDir.boolValue {
+                resolvedPrefix = candidateDir
+                currentComponent = segments[i]
+            } else {
+                currentComponent = currentComponent + "-" + segments[i]
+            }
+            i += 1
+        }
+
+        let inferred = resolvedPrefix + "/" + currentComponent
+        return inferred == "/" ? nil : inferred
     }
 
     private static func stringifyJSONValue(_ value: Any?) -> String? {

--- a/AgentSessionsTests/BuddySessionParserTests.swift
+++ b/AgentSessionsTests/BuddySessionParserTests.swift
@@ -48,6 +48,51 @@ final class BuddySessionParserTests: XCTestCase {
         XCTAssertEqual(preview.model, "buddy-test-model")
     }
 
+    func testParseFile_preview_acceptsSnakeCaseSessionAndSecondTimestamps() throws {
+        let lines = [
+            #"{"event_type":"metadata","session_id":"snake-1","createdAt":"2026-05-01T17:00:00.000Z","projectRoot":"/tmp/snake-project","metadata":{"model":"buddy-snake-model"}}"#,
+            #"{"event_type":"message","session_id":"snake-1","created_at":1777654801,"message":{"role":"user","content":"Find schema drift text"}}"#,
+            #"{"event_type":"assistant_message","session_id":"snake-1","created_at":1777654802000,"message":{"content":"Found it."}}"#
+        ]
+        let url = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let preview = CodebuddySessionParser.parseFile(at: url) else {
+            return XCTFail("preview parse returned nil")
+        }
+        XCTAssertEqual(preview.codexInternalSessionIDHint, "snake-1")
+        XCTAssertEqual(preview.cwd, "/tmp/snake-project")
+        XCTAssertEqual(preview.model, "buddy-snake-model")
+        XCTAssertEqual(preview.lightweightTitle, "Find schema drift text")
+        XCTAssertEqual(try XCTUnwrap(preview.startTime).timeIntervalSince1970, 1_777_654_800, accuracy: 0.1)
+        XCTAssertEqual(try XCTUnwrap(preview.endTime).timeIntervalSince1970, 1_777_654_802, accuracy: 0.1)
+    }
+
+    func testParseFile_infersCWDFromProjectsDirectoryWhenMissing() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("buddy-project-path-\(UUID().uuidString)", isDirectory: true)
+        let expectedCWD = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("as-buddy-fixture", isDirectory: true)
+            .appendingPathComponent("project", isDirectory: true)
+        try fm.createDirectory(at: expectedCWD, withIntermediateDirectories: true)
+        let projectDir = base
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent("tmp-as-buddy-fixture-project", isDirectory: true)
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        let url = projectDir.appendingPathComponent("session.jsonl")
+        try Data(#"{"type":"message","sessionId":"cwd-path","timestamp":1777654801000,"role":"user","content":"Hi"}"#.utf8).write(to: url)
+        defer {
+            try? fm.removeItem(at: base)
+            try? fm.removeItem(at: URL(fileURLWithPath: "/tmp/as-buddy-fixture", isDirectory: true))
+        }
+
+        guard let preview = CodebuddySessionParser.parseFile(at: url) else {
+            return XCTFail("preview parse returned nil")
+        }
+        XCTAssertEqual(preview.cwd, expectedCWD.path)
+        XCTAssertEqual(preview.repoName, "project")
+    }
+
     func testParseFile_returnsNilWhenNoUserOrAssistantMessages() throws {
         let lines = [
             #"{"type":"function_call","sessionId":"x","timestamp":1700000000000,"name":"noop","arguments":"{}"}"#

--- a/AgentSessionsTests/SearchCoordinatorTests.swift
+++ b/AgentSessionsTests/SearchCoordinatorTests.swift
@@ -13,4 +13,80 @@ final class SearchCoordinatorTests: XCTestCase {
             [.codex]
         )
     }
+
+    func testSearchCoordinatorFindsLightweightCodeBuddyTranscriptThroughFallback() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("buddy-search-\(UUID().uuidString).jsonl")
+        try """
+        {"type":"message","sessionId":"buddy-search","timestamp":1777651201000,"cwd":"/tmp/as-buddy-fixture/project","role":"user","content":"UniqueBuddySearchToken"}
+        {"type":"message","sessionId":"buddy-search","timestamp":1777651202000,"cwd":"/tmp/as-buddy-fixture/project","role":"assistant","content":"Done."}
+        """.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        guard let preview = CodebuddySessionParser.parseFile(at: url, forcedID: "buddy-search") else {
+            return XCTFail("preview parse returned nil")
+        }
+        XCTAssertTrue(preview.events.isEmpty)
+
+        let coordinator = SearchCoordinator(store: BuddySearchStore())
+        let filters = Filters(
+            query: "UniqueBuddySearchToken",
+            dateFrom: nil,
+            dateTo: nil,
+            model: nil,
+            kinds: Set(SessionEventKind.allCases),
+            repoName: nil,
+            pathContains: nil
+        )
+        coordinator.start(
+            query: filters.query,
+            filters: filters,
+            includeCodex: false,
+            includeClaude: false,
+            includeGemini: false,
+            includeOpenCode: false,
+            includeHermes: false,
+            includeCopilot: false,
+            includeDroid: false,
+            includeOpenClaw: false,
+            includeCursor: false,
+            includeCodebuddy: true,
+            includeWorkbuddy: false,
+            enableDeepScan: false,
+            all: [preview]
+        )
+
+        for _ in 0..<60 {
+            if coordinator.results.contains(where: { $0.id == "buddy-search" }) { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTAssertEqual(coordinator.results.map(\.id), ["buddy-search"])
+    }
+}
+
+private final class BuddySearchStore: SearchSessionStoring {
+    private let codebuddyCache = TranscriptCache()
+    private let workbuddyCache = TranscriptCache()
+
+    func transcriptCache(for source: SessionSource) -> TranscriptCache? {
+        switch source {
+        case .codebuddy: return codebuddyCache
+        case .workbuddy: return workbuddyCache
+        default: return nil
+        }
+    }
+
+    func updateSession(_ session: Session) {}
+
+    func parseFull(session: Session) async -> Session? {
+        guard session.events.isEmpty else { return session }
+        let url = URL(fileURLWithPath: session.filePath)
+        switch session.source {
+        case .codebuddy:
+            return CodebuddySessionParser.parseFileFull(at: url, forcedID: session.id)
+        case .workbuddy:
+            return WorkbuddySessionParser.parseFileFull(at: url, forcedID: session.id)
+        default:
+            return session
+        }
+    }
 }

--- a/AgentSessionsTests/Stage0GoldenFixturesTests.swift
+++ b/AgentSessionsTests/Stage0GoldenFixturesTests.swift
@@ -156,6 +156,68 @@ final class Stage0GoldenFixturesTests: XCTestCase {
         XCTAssertFalse(full.events.isEmpty)
     }
 
+    func testCodeBuddyFixturesParse() throws {
+        let smallURL = FixturePaths.stage0FixtureURL("agents/codebuddy/small.jsonl")
+        guard let smallPreview = CodebuddySessionParser.parseFile(at: smallURL) else { return XCTFail("preview parse returned nil") }
+        XCTAssertEqual(smallPreview.source, .codebuddy)
+        XCTAssertTrue(smallPreview.events.isEmpty)
+        XCTAssertEqual(smallPreview.codexInternalSessionIDHint, "codebuddy_stage0_small")
+        XCTAssertEqual(smallPreview.model, "deepseek-v3")
+        XCTAssertEqual(smallPreview.cwd, "/tmp/as-buddy-fixture/project")
+        XCTAssertEqual(smallPreview.repoName, "project")
+        XCTAssertGreaterThan(smallPreview.eventCount, 0)
+
+        guard let smallFull = CodebuddySessionParser.parseFileFull(at: smallURL) else { return XCTFail("full parse returned nil") }
+        XCTAssertEqual(smallFull.source, .codebuddy)
+        XCTAssertEqual(smallFull.cwd, "/tmp/as-buddy-fixture/project")
+        XCTAssertTrue(smallFull.events.contains(where: { $0.kind == .user }))
+        XCTAssertTrue(smallFull.events.contains(where: { $0.kind == .assistant }))
+        XCTAssertTrue(smallFull.events.contains(where: { $0.kind == .tool_call }))
+        XCTAssertTrue(smallFull.events.contains(where: { $0.kind == .tool_result }))
+
+        let driftURL = FixturePaths.stage0FixtureURL("agents/codebuddy/schema_drift.jsonl")
+        guard let driftPreview = CodebuddySessionParser.parseFile(at: driftURL) else { return XCTFail("drift preview parse returned nil") }
+        XCTAssertEqual(driftPreview.codexInternalSessionIDHint, "codebuddy_stage0_drift")
+        XCTAssertEqual(driftPreview.model, "hunyuan-code")
+        XCTAssertEqual(driftPreview.lightweightTitle, "List the file you inspected and say done.")
+
+        guard let driftFull = CodebuddySessionParser.parseFileFull(at: driftURL) else { return XCTFail("drift full parse returned nil") }
+        XCTAssertTrue(driftFull.events.contains(where: { $0.kind == .tool_call }))
+        XCTAssertTrue(driftFull.events.contains(where: { $0.kind == .tool_result }))
+        XCTAssertFalse(metaEvents(withType: "checkpoint.saved", in: driftFull.events).isEmpty)
+    }
+
+    func testWorkBuddyFixturesParse() throws {
+        let smallURL = FixturePaths.stage0FixtureURL("agents/workbuddy/small.jsonl")
+        guard let smallPreview = WorkbuddySessionParser.parseFile(at: smallURL) else { return XCTFail("preview parse returned nil") }
+        XCTAssertEqual(smallPreview.source, .workbuddy)
+        XCTAssertTrue(smallPreview.events.isEmpty)
+        XCTAssertEqual(smallPreview.codexInternalSessionIDHint, "workbuddy_stage0_small")
+        XCTAssertEqual(smallPreview.model, "workbuddy-agent")
+        XCTAssertEqual(smallPreview.cwd, "/tmp/as-buddy-fixture/project")
+        XCTAssertEqual(smallPreview.repoName, "project")
+        XCTAssertGreaterThan(smallPreview.eventCount, 0)
+
+        guard let smallFull = WorkbuddySessionParser.parseFileFull(at: smallURL) else { return XCTFail("full parse returned nil") }
+        XCTAssertEqual(smallFull.source, .workbuddy)
+        XCTAssertEqual(smallFull.cwd, "/tmp/as-buddy-fixture/project")
+        XCTAssertTrue(smallFull.events.contains(where: { $0.kind == .user }))
+        XCTAssertTrue(smallFull.events.contains(where: { $0.kind == .assistant }))
+        XCTAssertTrue(smallFull.events.contains(where: { $0.kind == .tool_call }))
+        XCTAssertTrue(smallFull.events.contains(where: { $0.kind == .tool_result }))
+
+        let driftURL = FixturePaths.stage0FixtureURL("agents/workbuddy/schema_drift.jsonl")
+        guard let driftPreview = WorkbuddySessionParser.parseFile(at: driftURL) else { return XCTFail("drift preview parse returned nil") }
+        XCTAssertEqual(driftPreview.codexInternalSessionIDHint, "workbuddy_stage0_drift")
+        XCTAssertEqual(driftPreview.model, "workbuddy-desktop")
+        XCTAssertEqual(driftPreview.lightweightTitle, "Open the small file and summarize it.")
+
+        guard let driftFull = WorkbuddySessionParser.parseFileFull(at: driftURL) else { return XCTFail("drift full parse returned nil") }
+        XCTAssertTrue(driftFull.events.contains(where: { $0.kind == .tool_call }))
+        XCTAssertTrue(driftFull.events.contains(where: { $0.kind == .tool_result && $0.toolOutput == #"print("hello from fixture")"# }))
+        XCTAssertFalse(metaEvents(withType: "workspace.snapshot", in: driftFull.events).isEmpty)
+    }
+
     func testDroidSessionStoreAndStreamJSONFixturesParse() throws {
         let paths = [
             "agents/droid/session_store_small.jsonl",
@@ -294,7 +356,13 @@ final class Stage0GoldenFixturesTests: XCTestCase {
     // MARK: - Helpers
 
     private func metaEvents(withType type: String, in events: [SessionEvent]) -> [SessionEvent] {
-        metaEvents(containing: "\"type\":\"\(type)\"", in: events)
+        events.filter { event in
+            guard event.kind == .meta, let data = Data(base64Encoded: event.rawJSON),
+                  let decoded = String(data: data, encoding: .utf8) else { return false }
+            return decoded.contains("\"type\":\"\(type)\"")
+                || decoded.contains("\"event_type\":\"\(type)\"")
+                || decoded.contains("\"kind\":\"\(type)\"")
+        }
     }
 
     private func metaEvents(containing needle: String, in events: [SessionEvent]) -> [SessionEvent] {

--- a/Resources/Fixtures/stage0/agents/codebuddy/schema_drift.jsonl
+++ b/Resources/Fixtures/stage0/agents/codebuddy/schema_drift.jsonl
@@ -1,0 +1,6 @@
+{"event_type":"metadata","session_id":"codebuddy_stage0_drift","createdAt":"2026-05-01T17:00:00.000Z","workspace":{"path":"/tmp/as-buddy-fixture/project"},"metadata":{"model":"hunyuan-code"}}
+{"event_type":"message","session_id":"codebuddy_stage0_drift","created_at":1777654801000000,"message":{"role":"user","content":[{"text":{"value":"List the file you inspected and say done."}}]}}
+{"event_type":"tool_use","session_id":"codebuddy_stage0_drift","created_at":1777654802000000000,"tool":{"name":"list_dir"},"input":{"path":"."}}
+{"event_type":"tool_result","session_id":"codebuddy_stage0_drift","created_at":"1777654803","toolName":"list_dir","result":["hello.py"]}
+{"event_type":"assistant_message","session_id":"codebuddy_stage0_drift","updatedAt":"2026-05-01T17:00:04Z","message":{"content":"Inspected hello.py. done"}}
+{"event_type":"checkpoint.saved","session_id":"codebuddy_stage0_drift","updatedAt":"2026-05-01T17:00:05Z","payload":{"note":"unknown event should survive as meta"}}

--- a/Resources/Fixtures/stage0/agents/codebuddy/small.jsonl
+++ b/Resources/Fixtures/stage0/agents/codebuddy/small.jsonl
@@ -1,0 +1,6 @@
+{"type":"session_start","sessionId":"codebuddy_stage0_small","timestamp":"2026-05-01T16:00:00.000Z","cwd":"/tmp/as-buddy-fixture/project","model":"deepseek-v3"}
+{"type":"message","sessionId":"codebuddy_stage0_small","timestamp":1777651201,"role":"user","content":"Read hello.py and summarize this tiny project."}
+{"type":"message","sessionId":"codebuddy_stage0_small","timestamp":1777651202500,"role":"assistant","content":[{"type":"text","text":"I will inspect the file."}]}
+{"type":"function_call","sessionId":"codebuddy_stage0_small","timestamp":1777651203000,"name":"read_file","arguments":{"path":"hello.py"}}
+{"type":"function_call_result","sessionId":"codebuddy_stage0_small","timestamp":1777651203500,"name":"read_file","output":"print(\"hello from fixture\")"}
+{"type":"message","sessionId":"codebuddy_stage0_small","timestamp":1777651204,"role":"assistant","content":"The project contains a single Python file that prints a fixture greeting."}

--- a/Resources/Fixtures/stage0/agents/workbuddy/schema_drift.jsonl
+++ b/Resources/Fixtures/stage0/agents/workbuddy/schema_drift.jsonl
@@ -1,0 +1,6 @@
+{"kind":"conversation.created","conversation_id":"workbuddy_stage0_drift","time":"2026-05-01T19:00:00.000Z","projectRoot":"/tmp/as-buddy-fixture/project","model":"workbuddy-desktop"}
+{"kind":"message","conversation_id":"workbuddy_stage0_drift","time":1777662001,"author":{"role":"human"},"content":{"text":"Open the small file and summarize it."}}
+{"kind":"tool-call","conversation_id":"workbuddy_stage0_drift","time":1777662002000,"function":{"name":"open_file"},"parameters":{"path":"hello.py"}}
+{"kind":"tool-result","conversation_id":"workbuddy_stage0_drift","time":1777662003000000,"functionName":"open_file","message":{"content":"print(\"hello from fixture\")"}}
+{"kind":"message","conversation_id":"workbuddy_stage0_drift","time":"2026-05-01T19:00:04Z","author":{"role":"assistant"},"message":{"content":[{"text":"hello.py prints a fixture greeting."}]}}
+{"kind":"workspace.snapshot","conversation_id":"workbuddy_stage0_drift","time":"2026-05-01T19:00:05Z","files":["hello.py"]}

--- a/Resources/Fixtures/stage0/agents/workbuddy/small.jsonl
+++ b/Resources/Fixtures/stage0/agents/workbuddy/small.jsonl
@@ -1,0 +1,6 @@
+{"type":"session_start","sessionId":"workbuddy_stage0_small","timestamp":"2026-05-01T18:00:00.000Z","cwd":"/tmp/as-buddy-fixture/project","providerData":{"modelId":"workbuddy-agent"}}
+{"type":"message","sessionId":"workbuddy_stage0_small","timestamp":1777658401000,"role":"user","content":"Review the tiny project and report the result."}
+{"type":"message","sessionId":"workbuddy_stage0_small","timestamp":1777658402000,"role":"assistant","content":"I will inspect the workspace."}
+{"type":"function_call","sessionId":"workbuddy_stage0_small","timestamp":1777658403000,"name":"workspace_search","arguments":{"query":"hello"}}
+{"type":"function_call_result","sessionId":"workbuddy_stage0_small","timestamp":1777658404000,"name":"workspace_search","output":"hello.py"}
+{"type":"message","sessionId":"workbuddy_stage0_small","timestamp":1777658405000,"role":"assistant","content":"Found hello.py and completed the review."}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Improvements
 - Menu bar: Added Show/Hide Dock Icon and Quit commands, with a separator before Quit and safer Dock/menu-bar preference synchronization.
+- Sessions/Search: Added local CodeBuddy Code and WorkBuddy transcript browsing and search, with parser hardening for Buddy JSONL schema drift and source-controlled compatibility fixtures.
 
 ### Bug Fixes
 - Sessions/Search: Restored Codex Desktop sessions with old rollout dates sort by fresh activity, are picked up when their files change, and parse non-large unindexed transcripts during search so content such as email addresses is findable without deep scan.

--- a/docs/summaries/2026-05.md
+++ b/docs/summaries/2026-05.md
@@ -1,6 +1,8 @@
 # 2026-05 Summary
 
 - Restored Codex Desktop sessions with old rollout dates now sort by fresh activity, are picked up when their files change, and parse non-large unindexed transcripts during search so content such as email addresses is findable without deep scan.
+- Added local CodeBuddy Code and WorkBuddy transcript browsing/search support, with Buddy JSONL parser hardening for session-id, timestamp, content, tool event, and metadata schema drift.
+- Added source-controlled Buddy compatibility fixtures so preview parsing, full transcript parsing, tool events, unknown metadata, and lightweight search fallback are covered before release wording expands beyond local browsing/search.
 - The menu bar menu now includes Show/Hide Dock Icon and Quit commands, keeps Quit separated, and clears hidden-Dock state when disabling the menu bar item.
 - Claude Desktop local-agent transcripts under Claude's Application Support directory are now discovered, enriched with Desktop metadata, and shown in Unified Sessions with the `desk` surface pill.
 - Claude rows in Unified Sessions now reuse the same Agent-column `cli` and `desk` surface pills as Codex rows.


### PR DESCRIPTION
## Summary
- harden CodeBuddy/WorkBuddy JSONL parsing for camelCase/snake_case IDs, nested message content, nested tool calls/results, timestamp units, model/cwd variants, and unknown meta-event preservation
- add source-controlled CodeBuddy and WorkBuddy stage0 compatibility fixtures plus parser/search/discovery coverage
- keep Buddy out of FTS-backed indexing and prevent large unindexed Buddy logs from being full-parsed unless deep scan is enabled

## Validation
- Baseline before hardening: focused PR tests passed, 33 tests / 0 failures
- Baseline before hardening: Debug build passed
- `git diff --check`
- fixture scan: `rg -n "/Users/|@|token|secret|cookie|authorization|api[_-]?key|BEGIN PRIVATE" Resources/Fixtures/stage0/agents/codebuddy Resources/Fixtures/stage0/agents/workbuddy` returned no matches
- Focused Buddy/search/provider/stage0 suite after hardening: 56 tests / 0 failures
- `./scripts/xcode_test_stable.sh`: 734 tests, 3 skipped, 0 failures
- Debug build: `** BUILD SUCCEEDED **`
- Post-rebase focused Buddy/search/provider/stage0 suite: 56 tests / 0 failures

## Compatibility note
I could not capture fresh local vendor sessions on this machine: `codebuddy` is not installed and neither `~/.codebuddy` nor `~/.workbuddy` exists. The fixtures in this PR are source-controlled compatibility fixtures with representative Buddy schema drift, not authenticated redacted exports from a real local CodeBuddy/WorkBuddy run.

Before release or public marketing, @tanguofu or another Buddy user should confirm this branch against real local CodeBuddy and WorkBuddy session files, or provide redacted examples for fixture replacement/expansion. Public wording should stay limited to local transcript browsing/search until that verification lands.

Follow-up to #37.