### PR TITLE
fix(search): remove self-reference race in kickSearchIngest task tracking

### DIFF
--- a/AgentSessions/Search/SearchIngestService.swift
+++ b/AgentSessions/Search/SearchIngestService.swift
@@ -466,8 +466,18 @@ actor SearchIngestCoordinatorBox {
         return shouldRunAgain
     }
 
-    /// Records the running task for `source` so `cancelAll()` can stop it on teardown.
-    func track(_ task: Task<Void, Never>, for source: SessionSource) {
+    /// Creates the ingest task for `source` at `.utility` and records it under
+    /// `tasksBySource` in one actor-isolated step, so `cancelAll()` can never observe a
+    /// running-but-untracked task. Creation and storage have no suspension point between
+    /// them, so any later actor method (`cancelAll`, `finish`) is guaranteed to see the
+    /// task. Crucially, `operation` needs no reference to its own `Task`: this removes the
+    /// self-reference race a caller-side `var task: Task! = Task { track(task) }` hits, where
+    /// the detached body can read the still-nil implicitly-unwrapped optional before the
+    /// assignment lands and trap on the force-unwrap.
+    func startTracked(source: SessionSource, _ operation: @escaping @Sendable () async -> Void) {
+        let task = Task.detached(priority: .utility) {
+            await operation()
+        }
         tasksBySource[source] = task
     }
 

--- a/AgentSessions/Services/UnifiedSessionIndexer.swift
+++ b/AgentSessions/Services/UnifiedSessionIndexer.swift
@@ -2004,19 +2004,22 @@ final class UnifiedSessionIndexer: ObservableObject {
     private func kickSearchIngest(source: SessionSource) {
         guard searchIngestService != nil else { return }
         let coordinator = searchIngestCoordinator
-        var task: Task<Void, Never>!
-        task = Task.detached(priority: .utility) { [weak self] in
-            // Register with the coordinator as the very first statement, before any
-            // ingest work starts, so a `deinit`-time `cancelAll()` can never race ahead
-            // of tracking: there is no window where this task is running but absent
-            // from `tasksBySource`. (Previously `track` was posted from a second,
-            // unordered `Task { ... }` that could be scheduled after this task had
-            // already started — or finished — its ingest work.)
-            await coordinator.track(task, for: source)
-            guard let self else { return }
-            let decision = await coordinator.request(source: source)
-            guard decision == .startNow else { return }
-            await self.runSearchIngestLoop(source: source)
+        // The coordinator creates and tracks the ingest task in one actor-isolated step
+        // (see `SearchIngestCoordinatorBox.startTracked`). This preserves the invariant
+        // that a `deinit`-time `cancelAll()` can never race ahead of tracking — there is no
+        // window where the task is running but absent from `tasksBySource` — without the
+        // ingest body needing a reference to its own `Task`. A prior version assigned the
+        // detached task to a `var task: Task! = Task { track(task) }` and read that
+        // implicitly-unwrapped optional as the task's first statement; the detached body
+        // could run before the assignment landed, read a nil `task`, and trap on the
+        // force-unwrap (EXC_BREAKPOINT).
+        Task { [weak self] in
+            await coordinator.startTracked(source: source) {
+                guard let self else { return }
+                let decision = await coordinator.request(source: source)
+                guard decision == .startNow else { return }
+                await self.runSearchIngestLoop(source: source)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a crash reported in **4.1 (build 54)**: `EXC_BREAKPOINT | SIGTRAP` with top frame `closure #1 in UnifiedSessionIndexer.kickSearchIngest(source:)`.

## Root cause

`kickSearchIngest` created the search-ingest task like this:

```swift
var task: Task<Void, Never>!                    // nil
task = Task.detached(priority: .utility) { [weak self] in
    await coordinator.track(task, for: source)  // implicit force-unwrap of `task`
    ...
}
```

`track(_:)` takes a non-optional `Task`, so `track(task, …)` implicitly force-unwraps the IUO. `Task.detached` can begin executing its body on another thread **before** the `task = …` assignment lands, so the body reads a still-`nil` `task` and traps on the force-unwrap → `EXC_BREAKPOINT`/`SIGTRAP`. It's a self-reference race: the task needed a reference to itself before that reference was stored.

## Fix

Move task creation into the coordinator actor. New `SearchIngestCoordinatorBox.startTracked(source:_:)` creates the `.utility` detached task and records it in `tasksBySource` in one actor-isolated step — no suspension point between create and store. The ingest body no longer references its own `Task`, so the IUO and the race are gone.

The teardown invariant is preserved and strengthened: because create + store are serialized inside the actor with no `await` between them, `cancelAll()` can never observe a running-but-untracked task.

## Behavior preserved

- Cancellation still propagates (`runSearchIngestLoop` runs in the tracked detached task).
- `.utility` QoS on the ingest loop is unchanged.
- Off-actor execution unchanged (`Task.detached` inside an actor is non-isolated).
- Tracking still happens before the ingest body runs; `track/request/finish` ordering intact.
- `track(_:for:)` had exactly one caller and no test references it; it's replaced by `startTracked`.

## Testing

Not built here (macOS/AppKit target). Recommend a local build + the `SearchIngestTests` suite before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFF3WAuyVie3GoMDevAYbk)_