### PR TITLE
Make Claude Desktop chats first-class live presences

### DIFF
--- a/AgentSessions.xcodeproj/project.pbxproj
+++ b/AgentSessions.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		75055F7F31775F7DCCACF1F6 /* OpenClawBase64ImageScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6505213F3D72B128BB972BA3 /* OpenClawBase64ImageScanner.swift */; };
 		75476EC518543210673A5078 /* CodexImagesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5529F15E903A3BAA9CA4D5D3 /* CodexImagesWindowController.swift */; };
 		75AB375D3B16DDD792710BC4 /* PresenceEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50210801FB81379DF4E04A5 /* PresenceEngine.swift */; };
+		C1A0DE5C00000000000000A1 /* ClaudeDesktopPresenceScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0DE5C00000000000000A2 /* ClaudeDesktopPresenceScanner.swift */; };
 		762B01C22A09A791D84961F2 /* CodexAuthClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A5DAE765B5A08C0AB0012C /* CodexAuthClassifierTests.swift */; };
 		767434CE7D92B9BFF2BE0734 /* SessionViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A7DBE9280787FB4D64FBD6 /* SessionViewMode.swift */; };
 		79F61D0D12836CDD2A0CD265 /* FixturePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E2B6C946DA8195F448959F /* FixturePaths.swift */; };
@@ -899,6 +900,7 @@
 		D4ECF214EB1FA1A7D37628AA /* CopilotSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Copilot/CopilotSettings.swift; sourceTree = SOURCE_ROOT; };
 		D4FDB19BD9DB1AD8419CD3A4 /* AppEdition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Support/AppEdition.swift; sourceTree = SOURCE_ROOT; };
 		D50210801FB81379DF4E04A5 /* PresenceEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/PresenceEngine.swift; sourceTree = SOURCE_ROOT; };
+		C1A0DE5C00000000000000A2 /* ClaudeDesktopPresenceScanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/ClaudeDesktopPresenceScanner.swift; sourceTree = SOURCE_ROOT; };
 		D5110A5BF02ABA14BB8B0AE6 /* CursorResumeCommandBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/CursorResumeCommandBuilderTests.swift; sourceTree = SOURCE_ROOT; };
 		D5C68DFDDE07CC8C0EE7E6E6 /* PerfSignpost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Support/PerfSignpost.swift; sourceTree = SOURCE_ROOT; };
 		D641BFBD310B4157871F120F /* CodexCLIEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodexCLIEnvironment.swift; path = AgentSessions/Resume/CodexCLIEnvironment.swift; sourceTree = SOURCE_ROOT; };
@@ -1690,6 +1692,7 @@
 				E6D3ED86146B4B32B6F5D8B5 /* TranscriptUserAnchors.swift */,
 				BB75F3F9039364653982EAE5 /* PresenceSnapshot.swift */,
 				D50210801FB81379DF4E04A5 /* PresenceEngine.swift */,
+				C1A0DE5C00000000000000A2 /* ClaudeDesktopPresenceScanner.swift */,
 				16A4E88F760E29858ECDD340 /* TranscriptDerivedState.swift */,
 				1C201E7A38F59A4DD6496BF3 /* TranscriptToolSummary.swift */,
 				687FB31B2705945AFF892A9B /* TranscriptFindNavigator.swift */,
@@ -2524,6 +2527,7 @@
 				83EA221DD5EE026209A2B3DD /* SessionRowsBuilder.swift in Sources */,
 				4FF43096EE702D850223E232 /* PresenceSnapshot.swift in Sources */,
 				75AB375D3B16DDD792710BC4 /* PresenceEngine.swift in Sources */,
+				C1A0DE5C00000000000000A1 /* ClaudeDesktopPresenceScanner.swift in Sources */,
 				5C214E362AFD0C863BF310C6 /* FilteredDefaultsObserver.swift in Sources */,
 				395E6D4526FA9B5E4D6B5E96 /* ListScrubSignal.swift in Sources */,
 				6E4E811077CD7A54E07082E6 /* LRUCache.swift in Sources */,

--- a/AgentSessions/Services/ClaudeDesktopPresenceScanner.swift
+++ b/AgentSessions/Services/ClaudeDesktopPresenceScanner.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Synthesizes live presences for Claude **Desktop** chats.
+///
+/// Desktop chats are written by the Claude GUI app: no tty, no terminal process, no iTerm
+/// session — so none of the existing discovery probes (registry, ps/lsof, iTerm) can see
+/// them. Their transcripts in `~/.claude/projects/<project>/<session>.jsonl` are the only
+/// footprint. This scanner turns recently-written transcripts into `CodexActivePresence`
+/// values (source `.claude`, `kind == "desktop"`) so Desktop chats flow through the same
+/// classify → publish → join pipeline as every other live session: the sessions-list dot,
+/// the Cockpit HUD, and the Stream Deck bridge all pick them up with no special-casing.
+enum ClaudeDesktopPresenceScanner {
+    /// Marker used on synthesized presences; the live-state classifier keys on this.
+    static let desktopKind = "desktop"
+    /// Transcripts untouched for longer than this are not "live" — no presence is emitted.
+    static let liveWindow: TimeInterval = 30 * 60
+    /// Upper bound on emitted presences per cycle (most-recent wins).
+    static let maxPresences = 32
+
+    static func normalizePath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    /// Scan the Claude session roots for recently-modified top-level transcripts that no
+    /// existing presence already claims, and synthesize Desktop presences for them.
+    ///
+    /// The Claude root is `~/.claude` (per `ClaudeSessionDiscovery.sessionsRoot()`); the
+    /// transcripts live at `projects/<project>/<session>.jsonl`, so the walk targets the
+    /// `projects` subtree. Subagent transcripts live deeper (`<project>/<session>/subagents/…`)
+    /// and are deliberately skipped by not descending past the project level.
+    static func scan(roots: [String],
+                     now: Date,
+                     excludingNormalizedLogPaths claimed: Set<String>) -> [CodexActivePresence] {
+        let fm = FileManager.default
+        var candidates: [(path: String, mtime: Date)] = []
+
+        for root in roots {
+            let rootURL = URL(fileURLWithPath: root, isDirectory: true)
+            let projectsURL = rootURL.appendingPathComponent("projects", isDirectory: true)
+            var isDir: ObjCBool = false
+            let scanBase = (fm.fileExists(atPath: projectsURL.path, isDirectory: &isDir) && isDir.boolValue)
+                ? projectsURL : rootURL
+            let keys: [URLResourceKey] = [.isDirectoryKey, .contentModificationDateKey]
+            guard let enumerator = fm.enumerator(at: scanBase,
+                                                 includingPropertiesForKeys: keys,
+                                                 options: [.skipsHiddenFiles]) else { continue }
+            let baseDepth = scanBase.standardizedFileURL.pathComponents.count
+            for case let url as URL in enumerator {
+                let depth = url.standardizedFileURL.pathComponents.count - baseDepth
+                let values = try? url.resourceValues(forKeys: Set(keys))
+                if values?.isDirectory == true {
+                    // Descend into project dirs (depth 1) only — session subdirs hold subagents.
+                    if depth >= 2 { enumerator.skipDescendants() }
+                    continue
+                }
+                guard depth <= 2, url.pathExtension == "jsonl" else { continue }
+                guard let mtime = values?.contentModificationDate,
+                      now.timeIntervalSince(mtime) <= liveWindow else { continue }
+                guard !claimed.contains(normalizePath(url.path)) else { continue }
+                candidates.append((url.path, mtime))
+            }
+        }
+
+        return candidates
+            .sorted { $0.mtime > $1.mtime }
+            .prefix(maxPresences)
+            .map { candidate in
+                var presence = CodexActivePresence()
+                presence.source = .claude
+                presence.kind = desktopKind
+                presence.publisher = "claude-desktop-scan"
+                presence.sessionId = URL(fileURLWithPath: candidate.path)
+                    .deletingPathExtension().lastPathComponent
+                presence.sessionLogPath = candidate.path
+                presence.sourceFilePath = candidate.path
+                presence.lastSeenAt = now
+                return presence
+            }
+    }
+
+    /// Whose turn is it? Reads only the transcript tail. `true` when the last substantive
+    /// entry is an assistant message that ENDS its turn (the user should respond).
+    ///
+    /// Subtlety: tool calls are assistant messages too (`tool_use` blocks), so "assistant
+    /// last" alone does NOT mean the turn is over — a running tool means the agent is still
+    /// working. A `user` entry (tool results ride in user entries) also means mid-turn.
+    static func lastTurnIsEndOfAssistantTurn(logPath: String?) -> Bool? {
+        guard let logPath, let handle = FileHandle(forReadingAtPath: logPath) else { return nil }
+        defer { try? handle.close() }
+        guard let end = try? handle.seekToEnd() else { return nil }
+        let tail: UInt64 = 16384
+        try? handle.seek(toOffset: end > tail ? end - tail : 0)
+        guard let data = try? handle.readToEnd() else { return nil }
+        for line in String(decoding: data, as: UTF8.self).split(separator: "\n").reversed() {
+            guard line.first == "{",
+                  let lineData = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = object["type"] as? String else { continue }
+            if type == "user" { return false }        // tool result / user prompt => mid-turn
+            guard type == "assistant" else { continue }
+            let message = object["message"] as? [String: Any]
+            if let stop = message?["stop_reason"] as? String, stop == "tool_use" { return false }
+            if let content = message?["content"] as? [[String: Any]],
+               let lastBlock = content.last?["type"] as? String, lastBlock == "tool_use" {
+                return false                            // tool running => still working
+            }
+            return true                                 // assistant finished its turn
+        }
+        return nil
+    }
+}

--- a/AgentSessions/Services/ClaudeDesktopPresenceScanner.swift
+++ b/AgentSessions/Services/ClaudeDesktopPresenceScanner.swift
@@ -22,7 +22,8 @@ enum ClaudeDesktopPresenceScanner {
     }
 
     /// Scan the Claude session roots for recently-modified top-level transcripts that no
-    /// existing presence already claims, and synthesize Desktop presences for them.
+    /// existing presence already claims and that were written by the Desktop app (see
+    /// `isClaudeDesktopTranscript`), and synthesize Desktop presences for them.
     ///
     /// The Claude root is `~/.claude` (per `ClaudeSessionDiscovery.sessionsRoot()`); the
     /// transcripts live at `projects/<project>/<session>.jsonl`, so the walk targets the
@@ -63,11 +64,13 @@ enum ClaudeDesktopPresenceScanner {
 
         return candidates
             .sorted { $0.mtime > $1.mtime }
+            .filter { isClaudeDesktopTranscript(logPath: $0.path) }
             .prefix(maxPresences)
             .map { candidate in
                 var presence = CodexActivePresence()
                 presence.source = .claude
                 presence.kind = desktopKind
+                presence.schemaVersion = 1
                 presence.publisher = "claude-desktop-scan"
                 presence.sessionId = URL(fileURLWithPath: candidate.path)
                     .deletingPathExtension().lastPathComponent
@@ -78,12 +81,35 @@ enum ClaudeDesktopPresenceScanner {
             }
     }
 
-    /// Whose turn is it? Reads only the transcript tail. `true` when the last substantive
-    /// entry is an assistant message that ENDS its turn (the user should respond).
+    /// True when the transcript was written by the Claude **Desktop** app, identified by the
+    /// `entrypoint == "claude-desktop"` marker its records carry. Claude Code CLI transcripts
+    /// live in the same `projects` tree but carry `entrypoint == "cli"` and already have a
+    /// terminal/iTerm footprint the other probes claim; requiring the Desktop marker keeps an
+    /// exited CLI session from lingering as a phantom live Desktop presence for the window.
+    /// Reads only the head (the marker rides on the first user/assistant record), bounded to
+    /// the already-window-filtered candidates so it stays cheap.
+    private static func isClaudeDesktopTranscript(logPath: String) -> Bool {
+        guard let handle = FileHandle(forReadingAtPath: logPath) else { return false }
+        defer { try? handle.close() }
+        let head = (try? handle.read(upToCount: 96 * 1024)) ?? Data()
+        guard !head.isEmpty else { return false }
+        for line in String(decoding: head, as: UTF8.self).split(separator: "\n").prefix(200) {
+            guard line.first == "{",
+                  let lineData = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let entrypoint = object["entrypoint"] as? String else { continue }
+            return entrypoint == "claude-desktop"
+        }
+        return false
+    }
+
+    /// Whose turn is it? Reads only the transcript tail. `true` only when the newest
+    /// assistant message handed the turn back to the user — a `stop_reason` of `end_turn`
+    /// or `stop_sequence`, matching `ClaudeRunwayRecentSessionScanner.isIdleMarker`.
     ///
-    /// Subtlety: tool calls are assistant messages too (`tool_use` blocks), so "assistant
-    /// last" alone does NOT mean the turn is over — a running tool means the agent is still
-    /// working. A `user` entry (tool results ride in user entries) also means mid-turn.
+    /// Everything else means still working: a `tool_use` stop (a tool is running), a
+    /// non-terminal stop (`max_tokens`, `null`, `refusal`), or a trailing `user` entry
+    /// (tool results ride in user entries). Returns nil only when the tail can't be read.
     static func lastTurnIsEndOfAssistantTurn(logPath: String?) -> Bool? {
         guard let logPath, let handle = FileHandle(forReadingAtPath: logPath) else { return nil }
         defer { try? handle.close() }
@@ -98,13 +124,10 @@ enum ClaudeDesktopPresenceScanner {
                   let type = object["type"] as? String else { continue }
             if type == "user" { return false }        // tool result / user prompt => mid-turn
             guard type == "assistant" else { continue }
-            let message = object["message"] as? [String: Any]
-            if let stop = message?["stop_reason"] as? String, stop == "tool_use" { return false }
-            if let content = message?["content"] as? [[String: Any]],
-               let lastBlock = content.last?["type"] as? String, lastBlock == "tool_use" {
-                return false                            // tool running => still working
+            guard let stop = (object["message"] as? [String: Any])?["stop_reason"] as? String else {
+                return false                            // no terminal stop yet => still working
             }
-            return true                                 // assistant finished its turn
+            return stop == "end_turn" || stop == "stop_sequence"
         }
         return nil
     }

--- a/AgentSessions/Services/CodexActiveSessionsModel.swift
+++ b/AgentSessions/Services/CodexActiveSessionsModel.swift
@@ -2221,6 +2221,24 @@ final class CodexActiveSessionsModel {
                     }
                     // No match → fall through to mtime heuristic
                 }
+            } else if presence.source == .claude, presence.kind == ClaudeDesktopPresenceScanner.desktopKind {
+                // Claude Desktop chats: no tty/iTerm to probe. A transcript being written
+                // right now means the agent is working; otherwise whose-turn comes from the
+                // transcript tail — assistant last => the agent finished and is waiting on
+                // the user (openIdle); user/tool last => the agent is presumed mid-turn.
+                let heuristic = heuristicLiveStateFromLogMTime(
+                    logPath: presence.sessionLogPath,
+                    sourceFilePath: presence.sourceFilePath,
+                    now: now,
+                    activeWriteWindow: activeWriteWindow(for: .claude)
+                )
+                if heuristic == .activeWorking {
+                    state = .activeWorking
+                } else if ClaudeDesktopPresenceScanner.lastTurnIsEndOfAssistantTurn(logPath: presence.sessionLogPath) == true {
+                    state = .openIdle
+                } else {
+                    state = .activeWorking
+                }
             }
 
             var activeWriteWindow = activeWriteWindow(for: presence.source)

--- a/AgentSessions/Services/CodexActiveSessionsModel.swift
+++ b/AgentSessions/Services/CodexActiveSessionsModel.swift
@@ -2224,8 +2224,9 @@ final class CodexActiveSessionsModel {
             } else if presence.source == .claude, presence.kind == ClaudeDesktopPresenceScanner.desktopKind {
                 // Claude Desktop chats: no tty/iTerm to probe. A transcript being written
                 // right now means the agent is working; otherwise whose-turn comes from the
-                // transcript tail — assistant last => the agent finished and is waiting on
-                // the user (openIdle); user/tool last => the agent is presumed mid-turn.
+                // transcript tail. Only a definitively mid-turn tail (tool result pending or
+                // a non-terminal stop) keeps it working; a turn handed back to the user, or a
+                // tail we can't read, prefers openIdle rather than asserting a false "working".
                 let heuristic = heuristicLiveStateFromLogMTime(
                     logPath: presence.sessionLogPath,
                     sourceFilePath: presence.sourceFilePath,
@@ -2234,10 +2235,10 @@ final class CodexActiveSessionsModel {
                 )
                 if heuristic == .activeWorking {
                     state = .activeWorking
-                } else if ClaudeDesktopPresenceScanner.lastTurnIsEndOfAssistantTurn(logPath: presence.sessionLogPath) == true {
-                    state = .openIdle
-                } else {
+                } else if ClaudeDesktopPresenceScanner.lastTurnIsEndOfAssistantTurn(logPath: presence.sessionLogPath) == false {
                     state = .activeWorking
+                } else {
+                    state = .openIdle
                 }
             }
 

--- a/AgentSessions/Services/PresenceEngine.swift
+++ b/AgentSessions/Services/PresenceEngine.swift
@@ -1012,6 +1012,20 @@ actor PresenceEngine {
             out.append(contentsOf: itermPresences)
         }
 
+        // Claude Desktop chats leave no process/tty/iTerm footprint — only their transcript
+        // files. Synthesize presences for recently-written transcripts no probe has claimed,
+        // so Desktop chats become first-class live sessions in the same pipeline.
+        let claimedLogPaths = Set(out.flatMap { presence -> [String] in
+            var paths = presence.openSessionLogPaths
+            if let logPath = presence.sessionLogPath { paths.append(logPath) }
+            return paths
+        }.map { ClaudeDesktopPresenceScanner.normalizePath($0) })
+        out.append(contentsOf: ClaudeDesktopPresenceScanner.scan(
+            roots: claudeSessionRoots,
+            now: now,
+            excludingNormalizedLogPaths: claimedLogPaths
+        ))
+
         return RefreshDiscoveryResult(
             loaded: out,
             didProbeProcesses: shouldProbeProcesses,


### PR DESCRIPTION
## Make Claude Desktop chats first-class live presences

Claude **Desktop** (GUI) chats leave no tty, terminal process, or iTerm session, so none of the existing discovery probes (registry, `ps`/`lsof`, iTerm) can see them — the only footprint they leave is their transcript at `~/.claude/projects/<project>/<session>.jsonl`. Today they show up in history/search but never as *live* sessions.

This makes them first-class live presences by synthesizing them from their transcripts, so they flow through the exact same `classify → publish → join` pipeline as every other live session — the sessions-list dot and the Cockpit HUD pick them up with **no view changes**.

### What changed (3 files, additive)

- **`Services/ClaudeDesktopPresenceScanner.swift`** (new) — scans the `projects` subtree (top level only; subagent transcripts live deeper and are deliberately skipped), and for each transcript modified within a 30-minute live window that no existing presence already claims, emits a `CodexActivePresence` with `source == .claude`, `kind == "desktop"`. Capped at 32 presences/cycle, most-recent first. Also a small tail-reader, `lastTurnIsEndOfAssistantTurn`, used by the classifier.
- **`Services/PresenceEngine.swift`** — `performRefreshDiscovery` appends the scan after the existing iTerm/process discovery, excluding log paths already claimed by other presences (so a Codex/iTerm session that happens to be Claude isn't double-counted).
- **`Services/CodexActiveSessionsModel.swift`** — `classifyLiveStates` gains a branch for desktop presences: an actively-written transcript ⇒ `activeWorking`; otherwise the transcript tail decides whose turn it is — an assistant message that *ends* its turn ⇒ `openIdle` (waiting on the user), a `user`/tool entry last ⇒ presumed mid-turn. `tool_use` is handled explicitly so a long-running tool reads as *working*, not *waiting*.

### Notes

- **Zero network, zero new dependencies** — everything is local transcript reads (tail only, 16 KB).
- **No UI changes** — purely feeds the existing presence pipeline; existing consumers light up automatically.
- Builds clean against `v4.6.3`.

I've been running this locally for a while against a fleet of parallel Claude Desktop + Code sessions and it's been solid. Happy to adjust naming/placement or the live-window constant to match your conventions.
