### PR TITLE
feat(grok): add Grok CLI as a session source

### DIFF
--- a/AgentSessions.xcodeproj/project.pbxproj
+++ b/AgentSessions.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		03BDFF835F9143C3EBF01DEC /* HermesSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE7B30494D96E4126CE07B7 /* HermesSettings.swift */; };
 		041A42D3A4AB688C27C72431 /* ResumeTerminalDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B052D38BAE27EF89F8E4D9B /* ResumeTerminalDispatchTests.swift */; };
 		0422F5CD85576F5A7193A15F /* OpenCodeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A1CB8D054EBD47772E5C0B /* OpenCodeSettings.swift */; };
+		04E53CF252B08F674DD2BCDC /* PreferencesView+Grok.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3AC84E87956640D1542A2DF /* PreferencesView+Grok.swift */; };
 		04EF3AF42BF8AD0871A5D2D2 /* ClaudeCloudHUDRowMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF913F1A4F8CD46819746264 /* ClaudeCloudHUDRowMapper.swift */; };
 		05625C624091572B992770F4 /* PiCLIEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69E3D47CFDBE3865D4451F94 /* PiCLIEnvironment.swift */; };
 		058A5BF45C6B3E1CF77F5EC3 /* CodexSessionImagePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B14E8BFD378E6311D3E2F55 /* CodexSessionImagePayload.swift */; };
@@ -33,6 +34,7 @@
 		09B8207EB33AAEC98F7BB8E9 /* ModelNameAbbreviator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49389E8BB4E189FC2B733B40 /* ModelNameAbbreviator.swift */; };
 		09C4E2A7C54B4EA3BF4473C7 /* CodexVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3233D9D6CE429AB0173B04 /* CodexVersion.swift */; };
 		0A148B0CD773BCEE4D2C7310 /* TranscriptWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADACF1B1E45C0ECAF1A0E98 /* TranscriptWindowTests.swift */; };
+		0AD12A61459A6A4128973F43 /* GrokSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A772851F854EEF10C4C598F8 /* GrokSettings.swift */; };
 		0B8F72366814B2724C5536B3 /* ClaudeProbeProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602CE18FB970A465454E6CF7 /* ClaudeProbeProject.swift */; };
 		0BED60C79B044F149BEF273F /* FeedbackSubmitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE5CCF20371FD6964A2F122 /* FeedbackSubmitterTests.swift */; };
 		0D2C09DA2327F5507792EE1A /* TerminalSemanticSegmentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10DE434722D491647B5D368 /* TerminalSemanticSegmentationTests.swift */; };
@@ -88,6 +90,7 @@
 		279FB3EB9AA895168F8BC9C9 /* SessionSearchTextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2BFBE4B73D06DDE72A35FF /* SessionSearchTextBuilder.swift */; };
 		27BB05A35A471ED1FFC1C708 /* AntigravityTranscriptParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5C3395AC2B4F1F9896C8D8 /* AntigravityTranscriptParser.swift */; };
 		27D65795FBB9A8C67FA36577 /* ClaudeRunwaySnapshotLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49D561C823DF3D2B9F08E1E /* ClaudeRunwaySnapshotLoader.swift */; };
+		280DB7685E2805A69F24CB31 /* GrokResumeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B4EE914BD68FD904299D40 /* GrokResumeCoordinator.swift */; };
 		288E91B39896BB860B423D66 /* ClaudeSessionIDHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC22A5E02E467F75F38C932 /* ClaudeSessionIDHelper.swift */; };
 		28E75806995F590B0ABA55F0 /* KimiResumeCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D278B7DB3B81B81E14D3CDA /* KimiResumeCommandBuilder.swift */; };
 		28E99A62167E3F8259961EBB /* RunwayPriceTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349A78100A34B0CEF7C7EB9E /* RunwayPriceTable.swift */; };
@@ -184,6 +187,7 @@
 		6522C054F1A5199237F6E4B8 /* KimiSessionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21CEA0B2A27ED7CBD8ACEDB /* KimiSessionParser.swift */; };
 		65C8631FB9EECB04C0453390 /* LRUCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086B93F46C722F12E0D60EB7 /* LRUCache.swift */; };
 		65EB88B78C3C117848D9BD06 /* SessionFilterShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC3DE188DC2AB5740BACF57 /* SessionFilterShims.swift */; };
+		665386744178D77715BCAF1A /* GrokSessionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7809493583BB17B3C78E7EDB /* GrokSessionParserTests.swift */; };
 		6665CBAA86C46336C23946D1 /* TerminalGlobalIdentityParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C6FF19C8D90E7888A3CC2 /* TerminalGlobalIdentityParityTests.swift */; };
 		67886527530D62D0C779167B /* ClaudeOAuthTokenResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445097A5E6BE27C7176AA8D0 /* ClaudeOAuthTokenResolver.swift */; };
 		6829C28DA0E1BEE5984B8599 /* DroidSessionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC5DFBBBA1745F69422B117 /* DroidSessionParserTests.swift */; };
@@ -274,6 +278,7 @@
 		95A7BF4CDFFEF52BFBD76994 /* CopilotSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ECF214EB1FA1A7D37628AA /* CopilotSettings.swift */; };
 		966CB97B11644A808CAE17D4 /* ResumePreferenceHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76AE362A94366A989622FA /* ResumePreferenceHelpers.swift */; };
 		96B87202DA151979911BE71C /* ClaudeProbeProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5612FE92135230B461DA0E59 /* ClaudeProbeProject.swift */; };
+		96F6DA28FDC23B880C3AFD9C /* GrokSessionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA061D9D15B2921DD9BBF13F /* GrokSessionDiscoveryTests.swift */; };
 		97BBDEB0289BEC85AA32BB91 /* PiSessionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A4B0DBEB6CE6812D3332F8 /* PiSessionDiscovery.swift */; };
 		9810431F71F24971F84E8472 /* HermesSessionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC465AC4F3A51868CBF81044 /* HermesSessionParser.swift */; };
 		98F981841A99410B940D88EE /* CodexLaunchMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979E7E3D0E14477885B20675 /* CodexLaunchMode.swift */; };
@@ -285,6 +290,7 @@
 		9B92B3472EF93B41FCF715A4 /* CursorTerminalLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4F664364626B00C234240A /* CursorTerminalLauncher.swift */; };
 		9C1C91D57A76756AB7386E12 /* PreferencesView+Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53969FF5B62664B3B8491411 /* PreferencesView+Cursor.swift */; };
 		9C341059F102D01661DFCB4E /* ClaudeCloudSessionCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F3B5C44B4685603BD64BC9 /* ClaudeCloudSessionCatalog.swift */; };
+		9D0102D46858E27F3CF617BB /* GrokCLIEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817B5A119F6C4E878E76C1EF /* GrokCLIEnvironment.swift */; };
 		9D5534E425C266C04EC76C0E /* ClaudeUsageSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B6E7D6ACA5F366D824ECD0 /* ClaudeUsageSnapshotStore.swift */; };
 		9D6563AF9CA04851C64E2A32 /* PresenceEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94814E2E2CFFA7EEBB199684 /* PresenceEngineTests.swift */; };
 		9DC4500913E0B79BC44F52CB /* CodexResetCredits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E33283F976696A8C7B0F29C /* CodexResetCredits.swift */; };
@@ -296,10 +302,12 @@
 		A00C5D82ECF78816C5F23742 /* ClaudeRunwayTokenActivityParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389079ECB645543E0ECC7212 /* ClaudeRunwayTokenActivityParser.swift */; };
 		A01BD908355EEF9D0B119406 /* KimiTerminalLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276598BD40E8FB807EBC6278 /* KimiTerminalLauncher.swift */; };
 		A04EC5C01C18611179B60046 /* ClaudeAuthClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520EA2A47376978BF4DA3B70 /* ClaudeAuthClassifier.swift */; };
+		A1177202EF3BD10EAACC7A3B /* GrokResumeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D291847A9AEA34F5A67AC0B /* GrokResumeTypes.swift */; };
 		A1B2C3D4E5F60708AA55BB66 /* MenuBarPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60708AA55BB65 /* MenuBarPrefs.swift */; };
 		A3C610591762D812570A3471 /* ClaudeUsageSnapshotStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC634024CF768951D08698DC /* ClaudeUsageSnapshotStoreTests.swift */; };
 		A3FBC9D1215900A5DB1DBDAF /* UsageAuthStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44D1929C2B6C30D94E20497 /* UsageAuthStatus.swift */; };
 		A3FE988DA89DB85892EE3C51 /* SessionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00000114A0A000100000001 /* SessionEvent.swift */; };
+		A42549D6FB8B2C022631A3D2 /* GrokResumeCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2310B96D8EA237386107F8C /* GrokResumeCommandBuilder.swift */; };
 		A58656799124497ABF30B977 /* AnalyticsColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46836E5B412F42D6B157696B /* AnalyticsColors.swift */; };
 		A6181F78682F0A5A838C94E4 /* InlineImageThumbnailGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759556107E9363A4AD558677 /* InlineImageThumbnailGridView.swift */; };
 		A6E88B46DC1595DBEFE72086 /* codex_051_usage.jsonl in Resources */ = {isa = PBXBuildFile; fileRef = 2504736A9D5ED08AB6B8B1FE /* codex_051_usage.jsonl */; };
@@ -307,9 +315,11 @@
 		A7F7596115762B845A507D83 /* HeadlessAgentPresenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4C4564CA93E42759CAAE8B /* HeadlessAgentPresenceTests.swift */; };
 		A84DC21DD4029749BF8BBD57 /* PreferencesView+Copilot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FAC728A9C11A666680AF44 /* PreferencesView+Copilot.swift */; };
 		A8891085C7123E3360E6513C /* OpenClawBase64ImageScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6505213F3D72B128BB972BA3 /* OpenClawBase64ImageScanner.swift */; };
+		A88DDAFABA7D3A83EFF77060 /* GrokSessionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC5D7D208F0938740D36803 /* GrokSessionDiscovery.swift */; };
 		A8B49E614242407C854A3463 /* CodexResumeLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD535A048F4C41ECA4435F9A /* CodexResumeLauncher.swift */; };
 		A8CFDE272E78DAC14CB5ACEB /* SearchIngestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3637ADBFD4A6E452C2DBD289 /* SearchIngestService.swift */; };
 		A91CE64676017F711232B3EC /* ClaudeCloudIsolationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF470F2E01088185373270BC /* ClaudeCloudIsolationTests.swift */; };
+		A91F095EC306E0A2963DF955 /* GrokSessionIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6313F796E19B021EF124F4 /* GrokSessionIndexer.swift */; };
 		A9BAC4A46E953DF0B8B146C3 /* SessionIndexingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654BD9FEF4DBAEA20EBC1254 /* SessionIndexingEngine.swift */; };
 		A9C8BC064D4751AA08618B32 /* MarkdownSourceMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF6CDF19503CE380FABF2E9 /* MarkdownSourceMapTests.swift */; };
 		A9D49F2A967D8DD12C2FD3FE /* OpenCodeBackendDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFE880E8C4F8CEFBE7FD3B6 /* OpenCodeBackendDetector.swift */; };
@@ -454,6 +464,7 @@
 		DDA741C3B926E44BF8ECAC4A /* OpenCodeTerminalLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1DBB5ECEA47B5F12AECF2A /* OpenCodeTerminalLauncher.swift */; };
 		DE0381FB79864EDCA2C58B03 /* CodexResumeCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABCAEC00B184A1F871509E5 /* CodexResumeCommandBuilder.swift */; };
 		DE03CB33E26820E114BDB87E /* ClaudeArchiveRestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E67E757675247C63DD9E02B /* ClaudeArchiveRestore.swift */; };
+		DE9D3B381F21B204C9799EFF /* GrokSessionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E61A5D0CB1016061A369AA /* GrokSessionParser.swift */; };
 		DEDB1FAC1D16EEA550415653 /* KeychainResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B180483734CCCEA78309FB /* KeychainResultTests.swift */; };
 		DEFB9060B8E3F2762D3A35EA /* NewProviderDiscoverabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5981003758B9226E65BA31D /* NewProviderDiscoverabilityTests.swift */; };
 		E048F5A3D6437615A927BF51 /* ClaudeUsageModelAuthWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941D05409259C45574C5D308 /* ClaudeUsageModelAuthWiringTests.swift */; };
@@ -504,6 +515,7 @@
 		F99D8667D52F20CA899A68B2 /* codex_053_rate_limit.jsonl in Resources */ = {isa = PBXBuildFile; fileRef = 01B00401B46F260749DB02B1 /* codex_053_rate_limit.jsonl */; };
 		FA139B7D4D793BC3019A618B /* Base64ImageDataURLScannerLineIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D27A124565438EA2EAD355 /* Base64ImageDataURLScannerLineIndexTests.swift */; };
 		FA83A7F3900C27BEF4EC5938 /* ClaudeProbeProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAF2FBE83AB906E7AE27B14 /* ClaudeProbeProjectTests.swift */; };
+		FAC02ED9CFCB98A670C8328F /* GrokTerminalLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E25CB5CACE0F23D0BCD09C /* GrokTerminalLauncher.swift */; };
 		FAECE68F3FD9BC86B24B54BF /* HermesResumeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE850504C7022449FBE19AC /* HermesResumeCoordinator.swift */; };
 		FC2C4C588AF83ABE67FB8868 /* DroidSessionParserLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E51A0ABB67AB9DE07F0F87 /* DroidSessionParserLogicTests.swift */; };
 		FCD400CC00A21391B30D6B32 /* TerminalKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827D113F4E69DE9468EC31AC /* TerminalKindTests.swift */; };
@@ -619,6 +631,7 @@
 		2AD090A12FD5A20691240A97 /* PreferencesView+Droid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentSessions/Views/Preferences/PreferencesView+Droid.swift"; sourceTree = SOURCE_ROOT; };
 		2B8EE5C41DFBD89E0EAD5976 /* PiResumeCommandBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/PiResume/PiResumeCommandBuilder.swift; sourceTree = SOURCE_ROOT; };
 		2C762CD19A1DFBAD37751955 /* CodexRunwayModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/CodexStatus/CodexRunwayModel.swift; sourceTree = SOURCE_ROOT; };
+		2D291847A9AEA34F5A67AC0B /* GrokResumeTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/GrokResume/GrokResumeTypes.swift; sourceTree = SOURCE_ROOT; };
 		2D70F11CF48AE82D03E7FA4D /* CodexCredentialReadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/CodexCredentialReadTests.swift; sourceTree = SOURCE_ROOT; };
 		2D7F765B9B19F8A039C30CDD /* ProbeCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Shared/ProbeCoordinator.swift; sourceTree = SOURCE_ROOT; };
 		2E33283F976696A8C7B0F29C /* CodexResetCredits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Utilities/CodexResetCredits.swift; sourceTree = SOURCE_ROOT; };
@@ -701,11 +714,13 @@
 		5612FE92135230B461DA0E59 /* ClaudeProbeProject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClaudeProbeProject.swift; sourceTree = "<group>"; };
 		575BC2E10FBE2EDB852CE870 /* ClaudeWebCookieParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/ClaudeOAuth/ClaudeWebCookieParserTests.swift; sourceTree = SOURCE_ROOT; };
 		5835994D198D1EDF93CC7E47 /* HUDRebuildGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/HUDRebuildGateTests.swift; sourceTree = SOURCE_ROOT; };
+		58E61A5D0CB1016061A369AA /* GrokSessionParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/GrokSessionParser.swift; sourceTree = SOURCE_ROOT; };
 		5937E9FEA9989BE235AC740E /* OnboardingPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Onboarding/Components/OnboardingPalette.swift; sourceTree = SOURCE_ROOT; };
 		59F809F7DFDB78DC70A32C3E /* CrashEmailDraftBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Support/CrashReporting/CrashEmailDraftBuilder.swift; sourceTree = SOURCE_ROOT; };
 		5A3745628762D9F93EDA7DA4 /* MigrationCorpusPreservationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/Indexing/MigrationCorpusPreservationTests.swift; sourceTree = SOURCE_ROOT; };
 		5A4F19A9B2F64DC7FB27B5B8 /* PiResumeCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/PiResumeCoordinatorTests.swift; sourceTree = SOURCE_ROOT; };
 		5A5C3395AC2B4F1F9896C8D8 /* AntigravityTranscriptParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/AntigravityTranscriptParser.swift; sourceTree = SOURCE_ROOT; };
+		5A6313F796E19B021EF124F4 /* GrokSessionIndexer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/GrokSessionIndexer.swift; sourceTree = SOURCE_ROOT; };
 		5ABCAEC00B184A1F871509E5 /* CodexResumeCommandBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodexResumeCommandBuilder.swift; path = AgentSessions/Resume/CodexResumeCommandBuilder.swift; sourceTree = SOURCE_ROOT; };
 		5ADACF1B1E45C0ECAF1A0E98 /* TranscriptWindowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/TranscriptWindowTests.swift; sourceTree = SOURCE_ROOT; };
 		5AE7B30494D96E4126CE07B7 /* HermesSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Hermes/HermesSettings.swift; sourceTree = SOURCE_ROOT; };
@@ -747,6 +762,7 @@
 		76B8E4F7C43F96D506B253AD /* ClaudeRunwayLogIO.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/ClaudeStatus/ClaudeRunwayLogIO.swift; sourceTree = SOURCE_ROOT; };
 		76F169690CB4AB0CCCD6119C /* CopilotTerminalLauncher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/CopilotResume/CopilotTerminalLauncher.swift; sourceTree = SOURCE_ROOT; };
 		77DFDD1AE593881F440C6C9A /* ClaudeArchivedFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsLogicTests/ClaudeArchivedFilterTests.swift; sourceTree = SOURCE_ROOT; };
+		7809493583BB17B3C78E7EDB /* GrokSessionParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/GrokSessionParserTests.swift; sourceTree = SOURCE_ROOT; };
 		78E501754B87E5B32487D01A /* IndexDBBackfillStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/Indexing/IndexDBBackfillStateTests.swift; sourceTree = SOURCE_ROOT; };
 		79714DEBBDCDA7E48A76E6F5 /* WhatsNewPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Onboarding/Views/WhatsNewPanelView.swift; sourceTree = SOURCE_ROOT; };
 		7B1DBB5ECEA47B5F12AECF2A /* OpenCodeTerminalLauncher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/OpenCodeResume/OpenCodeTerminalLauncher.swift; sourceTree = SOURCE_ROOT; };
@@ -760,6 +776,7 @@
 		7E8EFD200FFA4B90BCCF3434 /* CodexResumeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodexResumeSheet.swift; path = AgentSessions/Resume/CodexResumeSheet.swift; sourceTree = SOURCE_ROOT; };
 		812D088A294DD367D06A8842 /* Stage0PerfHarnessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/Stage0PerfHarnessTests.swift; sourceTree = SOURCE_ROOT; };
 		815DCA7C60A7B56BC748C548 /* CopilotTranscriptView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Views/CopilotTranscriptView.swift; sourceTree = SOURCE_ROOT; };
+		817B5A119F6C4E878E76C1EF /* GrokCLIEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Grok/GrokCLIEnvironment.swift; sourceTree = SOURCE_ROOT; };
 		818D69C24F0559B1CFE37700 /* AgentCockpitHUDWindow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Views/AgentCockpitHUDWindow.swift; sourceTree = SOURCE_ROOT; };
 		823FEF6C68602B417D574A96 /* ClaudeBase64ImageScannerLineIndexTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/ClaudeBase64ImageScannerLineIndexTests.swift; sourceTree = SOURCE_ROOT; };
 		827D113F4E69DE9468EC31AC /* TerminalKindTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/TerminalKindTests.swift; sourceTree = SOURCE_ROOT; };
@@ -803,6 +820,7 @@
 		984DB58B4EDFDA087B0B1623 /* CodexSessionImagesGalleryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Views/CodexSessionImagesGalleryView.swift; sourceTree = SOURCE_ROOT; };
 		9937314E038C466B657D7972 /* ClaudeManualWebCookie.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/ClaudeStatus/ClaudeOAuth/ClaudeManualWebCookie.swift; sourceTree = SOURCE_ROOT; };
 		99CD97A89CCCDCA326CCE023 /* AntigravityResumeTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/AntigravityResume/AntigravityResumeTypes.swift; sourceTree = SOURCE_ROOT; };
+		99E25CB5CACE0F23D0BCD09C /* GrokTerminalLauncher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/GrokResume/GrokTerminalLauncher.swift; sourceTree = SOURCE_ROOT; };
 		9A35FF4EC89DCD3987AD16BB /* OpenCodeSessionParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpenCodeSessionParser.swift; path = AgentSessions/Services/OpenCodeSessionParser.swift; sourceTree = SOURCE_ROOT; };
 		9B86A8EFF02D440EADEB98F0 /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UpdateChecker.swift; path = AgentSessions/Update/UpdateChecker.swift; sourceTree = SOURCE_ROOT; };
 		9BB42A027B568C1BC8DF6634 /* ReverseJSONLTailReaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/ReverseJSONLTailReaderTests.swift; sourceTree = SOURCE_ROOT; };
@@ -825,13 +843,16 @@
 		A27D0637DFF720558181BE5D /* ClaudeProbeConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClaudeProbeConfig.swift; sourceTree = "<group>"; };
 		A3167C6F5C43A594DD6BE934 /* AppDateFormatting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Utilities/AppDateFormatting.swift; sourceTree = SOURCE_ROOT; };
 		A35C4B3819D890B69E867FFB /* ClaudeUsageSourceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/ClaudeStatus/ClaudeOAuth/ClaudeUsageSourceManager.swift; sourceTree = SOURCE_ROOT; };
+		A3AC84E87956640D1542A2DF /* PreferencesView+Grok.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentSessions/Views/Preferences/PreferencesView+Grok.swift"; sourceTree = SOURCE_ROOT; };
 		A3CCBF527BA086AC5896EDD1 /* TranscriptRenderGenerationGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/TranscriptRenderGenerationGateTests.swift; sourceTree = SOURCE_ROOT; };
 		A41F008CC9A18910C72A1A43 /* KimiSessionDiscoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/KimiSessionDiscoveryTests.swift; sourceTree = SOURCE_ROOT; };
 		A427D60CA024824068C5D6E6 /* UnifiedDiffParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/UnifiedDiffParser.swift; sourceTree = SOURCE_ROOT; };
 		A49D561C823DF3D2B9F08E1E /* ClaudeRunwaySnapshotLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/ClaudeStatus/ClaudeRunwaySnapshotLoader.swift; sourceTree = SOURCE_ROOT; };
+		A5B4EE914BD68FD904299D40 /* GrokResumeCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/GrokResume/GrokResumeCoordinator.swift; sourceTree = SOURCE_ROOT; };
 		A62B8D98322763D14AF6ACF7 /* ColumnVisibilityStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ColumnVisibilityStore.swift; path = AgentSessions/Support/ColumnVisibilityStore.swift; sourceTree = SOURCE_ROOT; };
 		A64863D6D14C1126A51A141E /* IndexDBTestHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/Helpers/IndexDBTestHelpers.swift; sourceTree = SOURCE_ROOT; };
 		A68F04B1FE6FAB14000F57CF /* KimiSessionParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/KimiSessionParserTests.swift; sourceTree = SOURCE_ROOT; };
+		A772851F854EEF10C4C598F8 /* GrokSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Grok/GrokSettings.swift; sourceTree = SOURCE_ROOT; };
 		A8038F1B15229405969C3C5E /* ClaudeManualWebCookieTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/ClaudeOAuth/ClaudeManualWebCookieTests.swift; sourceTree = SOURCE_ROOT; };
 		A80E2D7915DCA094DE383D10 /* CopyResumeCommandTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/CopyResumeCommandTests.swift; sourceTree = SOURCE_ROOT; };
 		A85CE64F2E8C4DCFAFF1B93C /* CodexResumeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CodexResumeTests.swift; path = AgentSessionsTests/CodexResumeTests.swift; sourceTree = SOURCE_ROOT; };
@@ -981,6 +1002,7 @@
 		E17FB1E129787D35D02F800D /* SearchSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Search/SearchSessionStore.swift; sourceTree = SOURCE_ROOT; };
 		E1A54A306BCA0B6CAF2152FA /* PreferencesView+OpenCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PreferencesView+OpenCode.swift"; path = "AgentSessions/Views/Preferences/PreferencesView+OpenCode.swift"; sourceTree = SOURCE_ROOT; };
 		E1F2A3B4C5D60708FFEEDDCC /* UsageMenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UsageMenuBar.swift; path = AgentSessions/MenuBar/UsageMenuBar.swift; sourceTree = SOURCE_ROOT; };
+		E2310B96D8EA237386107F8C /* GrokResumeCommandBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/GrokResume/GrokResumeCommandBuilder.swift; sourceTree = SOURCE_ROOT; };
 		E3563BD500FFE8112F014A44 /* ClaudeOAuthUsageClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/ClaudeStatus/ClaudeOAuth/ClaudeOAuthUsageClient.swift; sourceTree = SOURCE_ROOT; };
 		E391828E8CC449F1537258DE /* AntigravityMarkdownImageScanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Utilities/AntigravityMarkdownImageScanner.swift; sourceTree = SOURCE_ROOT; };
 		E401FF3CCED67F77E3FD9521 /* OnboardingSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Onboarding/Views/OnboardingSheetView.swift; sourceTree = SOURCE_ROOT; };
@@ -1025,9 +1047,11 @@
 		F907EDC5569C03CA84AC9963 /* CursorSessionParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/CursorSessionParser.swift; sourceTree = SOURCE_ROOT; };
 		F971741FC16E09106844B759 /* UsageAuthStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/UsageAuthStatusTests.swift; sourceTree = SOURCE_ROOT; };
 		F9894FB605C3046578ADD2EE /* ClaudeUsageNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/ClaudeOAuth/ClaudeUsageNormalizerTests.swift; sourceTree = SOURCE_ROOT; };
+		FA061D9D15B2921DD9BBF13F /* GrokSessionDiscoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/GrokSessionDiscoveryTests.swift; sourceTree = SOURCE_ROOT; };
 		FA4AF27F5AF69A264BEFC49E /* PreferencesView+Kimi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentSessions/Views/Preferences/PreferencesView+Kimi.swift"; sourceTree = SOURCE_ROOT; };
 		FB55F7E750EACD729AA8BE7E /* ActivationPolicyDeciderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/ActivationPolicyDeciderTests.swift; sourceTree = SOURCE_ROOT; };
 		FBB289E92C36F110C2431FEF /* RenderedBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/RenderedBody.swift; sourceTree = SOURCE_ROOT; };
+		FCC5D7D208F0938740D36803 /* GrokSessionDiscovery.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/GrokSessionDiscovery.swift; sourceTree = SOURCE_ROOT; };
 		FD4DB1D386011AE92EE08483 /* StarredSessionsStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/Services/StarredSessionsStore.swift; sourceTree = SOURCE_ROOT; };
 		FE67A3FD2DFC511CF301F796 /* AntigravityResumeCommandBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessions/AntigravityResume/AntigravityResumeCommandBuilder.swift; sourceTree = SOURCE_ROOT; };
 		FE85475F0B2EEDB639B0F200 /* ClaudeAuthClassifierTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentSessionsTests/ClaudeAuthClassifierTests.swift; sourceTree = SOURCE_ROOT; };
@@ -1332,6 +1356,26 @@
 			name = ClaudeCloud;
 			sourceTree = "<group>";
 		};
+		65FDD9AE0930C65960295397 /* Grok */ = {
+			isa = PBXGroup;
+			children = (
+				817B5A119F6C4E878E76C1EF /* GrokCLIEnvironment.swift */,
+				A772851F854EEF10C4C598F8 /* GrokSettings.swift */,
+			);
+			name = Grok;
+			sourceTree = "<group>";
+		};
+		660B9B1240CEF6C554E9FFB4 /* GrokResume */ = {
+			isa = PBXGroup;
+			children = (
+				2D291847A9AEA34F5A67AC0B /* GrokResumeTypes.swift */,
+				E2310B96D8EA237386107F8C /* GrokResumeCommandBuilder.swift */,
+				A5B4EE914BD68FD904299D40 /* GrokResumeCoordinator.swift */,
+				99E25CB5CACE0F23D0BCD09C /* GrokTerminalLauncher.swift */,
+			);
+			name = GrokResume;
+			sourceTree = "<group>";
+		};
 		66B25C9FEB44F03BF285A3D7 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
@@ -1562,6 +1606,8 @@
 				CEDA97161BA187D72AD38B57 /* KimiResume */,
 				6143FB6B11E533DBFFFF13D2 /* ClaudeCloud */,
 				6ED37C60AB35724DD43ED9CF /* Kimi */,
+				65FDD9AE0930C65960295397 /* Grok */,
+				660B9B1240CEF6C554E9FFB4 /* GrokResume */,
 			);
 			path = AgentSessions;
 			sourceTree = SOURCE_ROOT;
@@ -1697,6 +1743,8 @@
 				457932B81D1A49441E9DF41E /* OnboardingStarCardTests.swift */,
 				479D76D34879C41991540E02 /* KimiCLIEnvironmentTests.swift */,
 				5A4F19A9B2F64DC7FB27B5B8 /* PiResumeCoordinatorTests.swift */,
+				7809493583BB17B3C78E7EDB /* GrokSessionParserTests.swift */,
+				FA061D9D15B2921DD9BBF13F /* GrokSessionDiscoveryTests.swift */,
 			);
 			path = AgentSessionsTests;
 			sourceTree = SOURCE_ROOT;
@@ -1804,6 +1852,9 @@
 				C21CEA0B2A27ED7CBD8ACEDB /* KimiSessionParser.swift */,
 				EA32F828CDE290C5EFAA8E68 /* KimiSessionIndexer.swift */,
 				F4F0F146A64E3F13E7DE73C8 /* AnalyticsSourceSupport.swift */,
+				FCC5D7D208F0938740D36803 /* GrokSessionDiscovery.swift */,
+				58E61A5D0CB1016061A369AA /* GrokSessionParser.swift */,
+				5A6313F796E19B021EF124F4 /* GrokSessionIndexer.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1923,6 +1974,7 @@
 				DB6BB67FF1D624BE69835C91 /* PreferencesView+Hermes.swift */,
 				877C439473252C9A12E66380 /* PreferencesView+Pi.swift */,
 				FA4AF27F5AF69A264BEFC49E /* PreferencesView+Kimi.swift */,
+				A3AC84E87956640D1542A2DF /* PreferencesView+Grok.swift */,
 			);
 			name = Preferences;
 			sourceTree = "<group>";
@@ -2691,6 +2743,16 @@
 				C5F4AF2DCCED1CDFD8BF92EA /* KimiResumeTypes.swift in Sources */,
 				A01BD908355EEF9D0B119406 /* KimiTerminalLauncher.swift in Sources */,
 				6359582A54253CEDBA13455A /* KimiResumeCoordinator.swift in Sources */,
+				A88DDAFABA7D3A83EFF77060 /* GrokSessionDiscovery.swift in Sources */,
+				DE9D3B381F21B204C9799EFF /* GrokSessionParser.swift in Sources */,
+				A91F095EC306E0A2963DF955 /* GrokSessionIndexer.swift in Sources */,
+				9D0102D46858E27F3CF617BB /* GrokCLIEnvironment.swift in Sources */,
+				0AD12A61459A6A4128973F43 /* GrokSettings.swift in Sources */,
+				A1177202EF3BD10EAACC7A3B /* GrokResumeTypes.swift in Sources */,
+				A42549D6FB8B2C022631A3D2 /* GrokResumeCommandBuilder.swift in Sources */,
+				280DB7685E2805A69F24CB31 /* GrokResumeCoordinator.swift in Sources */,
+				FAC02ED9CFCB98A670C8328F /* GrokTerminalLauncher.swift in Sources */,
+				04E53CF252B08F674DD2BCDC /* PreferencesView+Grok.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2836,6 +2898,8 @@
 				60CCB24C77655665631605A0 /* OnboardingStarCardTests.swift in Sources */,
 				3FA0599B512AD9F633C4D90F /* KimiCLIEnvironmentTests.swift in Sources */,
 				838B44C1E47E299E299E84D4 /* PiResumeCoordinatorTests.swift in Sources */,
+				665386744178D77715BCAF1A /* GrokSessionParserTests.swift in Sources */,
+				96F6DA28FDC23B880C3AFD9C /* GrokSessionDiscoveryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AgentSessions/AgentSessionsApp.swift
+++ b/AgentSessions/AgentSessionsApp.swift
@@ -186,6 +186,7 @@ struct AgentSessionsApp: App {
     @StateObject private var cursorIndexer = CursorSessionIndexer()
     @StateObject private var piIndexer = PiSessionIndexer()
     @StateObject private var kimiIndexer = KimiSessionIndexer()
+    @StateObject private var grokIndexer = GrokSessionIndexer()
     @StateObject private var updaterController = UpdaterController()
     @StateObject private var onboardingCoordinator = OnboardingCoordinator()
     @StateObject private var unifiedIndexerHolder = _UnifiedHolder()
@@ -284,7 +285,8 @@ struct AgentSessionsApp: App {
                 openclawIndexer: openclawIndexer,
                 cursorIndexer: cursorIndexer,
                 piIndexer: piIndexer,
-                kimiIndexer: kimiIndexer
+                kimiIndexer: kimiIndexer,
+                grokIndexer: grokIndexer
             )
             configuredUnifiedWindow(unified: unified)
         }
@@ -306,6 +308,7 @@ struct AgentSessionsApp: App {
             cursorIndexer: cursorIndexer,
             piIndexer: piIndexer,
             kimiIndexer: kimiIndexer,
+            grokIndexer: grokIndexer,
             analyticsReady: analyticsReady,
             analyticsPhase: analyticsPhase,
             analyticsIsStale: analyticsStale,
@@ -390,6 +393,7 @@ struct AgentSessionsApp: App {
                     cursorIndexer: cursorIndexer,
                     piIndexer: piIndexer,
                     kimiIndexer: kimiIndexer,
+                    grokIndexer: grokIndexer,
                     codexUsageModel: codexUsageModel,
                     claudeUsageModel: claudeUsageModel
                 )
@@ -486,7 +490,8 @@ struct AgentSessionsApp: App {
                         openclawIndexer: openclawIndexer,
                         cursorIndexer: cursorIndexer,
                         piIndexer: piIndexer,
-                        kimiIndexer: kimiIndexer
+                        kimiIndexer: kimiIndexer,
+                        grokIndexer: grokIndexer
                     )
                 )
                 .environmentObject(archiveManager)
@@ -553,7 +558,8 @@ final class _UnifiedHolder: ObservableObject {
                      openclawIndexer: OpenClawSessionIndexer,
                      cursorIndexer: CursorSessionIndexer,
                      piIndexer: PiSessionIndexer,
-                     kimiIndexer: KimiSessionIndexer) -> UnifiedSessionIndexer {
+                     kimiIndexer: KimiSessionIndexer,
+                     grokIndexer: GrokSessionIndexer) -> UnifiedSessionIndexer {
         if let u = unified { return u }
         let u = UnifiedSessionIndexer(codexIndexer: codexIndexer,
                                       claudeIndexer: claudeIndexer,
@@ -565,7 +571,8 @@ final class _UnifiedHolder: ObservableObject {
                                       openclawIndexer: openclawIndexer,
                                       cursorIndexer: cursorIndexer,
                                       piIndexer: piIndexer,
-                                      kimiIndexer: kimiIndexer)
+                                      kimiIndexer: kimiIndexer,
+                                      grokIndexer: grokIndexer)
         unified = u
         return u
     }
@@ -783,7 +790,8 @@ extension AgentSessionsApp {
             openclawIndexer: openclawIndexer,
             cursorIndexer: cursorIndexer,
             piIndexer: piIndexer,
-            kimiIndexer: kimiIndexer
+            kimiIndexer: kimiIndexer,
+            grokIndexer: grokIndexer
         )
     }
 
@@ -1101,7 +1109,8 @@ extension AgentSessionsApp {
             copilotIndexer: copilotIndexer,
             droidIndexer: droidIndexer,
             piIndexer: piIndexer,
-            kimiIndexer: kimiIndexer
+            kimiIndexer: kimiIndexer,
+            grokIndexer: grokIndexer
         )
         analyticsService = service
 
@@ -1324,6 +1333,7 @@ final class OnboardingWindowPresenter: NSObject, NSWindowDelegate {
         cursorIndexer: CursorSessionIndexer,
         piIndexer: PiSessionIndexer,
         kimiIndexer: KimiSessionIndexer,
+        grokIndexer: GrokSessionIndexer,
         codexUsageModel: CodexUsageModel,
         claudeUsageModel: ClaudeUsageModel
     ) {
@@ -1342,6 +1352,7 @@ final class OnboardingWindowPresenter: NSObject, NSWindowDelegate {
             cursorIndexer: cursorIndexer,
             piIndexer: piIndexer,
             kimiIndexer: kimiIndexer,
+            grokIndexer: grokIndexer,
             codexUsageModel: codexUsageModel,
             claudeUsageModel: claudeUsageModel
         )
@@ -1435,6 +1446,7 @@ private struct OnboardingWindowState {
     let cursorIndexer: CursorSessionIndexer
     let piIndexer: PiSessionIndexer
     let kimiIndexer: KimiSessionIndexer
+    let grokIndexer: GrokSessionIndexer
     let codexUsageModel: CodexUsageModel
     let claudeUsageModel: ClaudeUsageModel
 }
@@ -1459,7 +1471,8 @@ private struct OnboardingWindowRoot: View {
                 openclawIndexer: state.openclawIndexer,
                 cursorIndexer: state.cursorIndexer,
                 piIndexer: state.piIndexer,
-                kimiIndexer: state.kimiIndexer
+                kimiIndexer: state.kimiIndexer,
+                grokIndexer: state.grokIndexer
             )
         case .powerTips(let content):
             OnboardingSheetView(

--- a/AgentSessions/Analytics/Services/AnalyticsService.swift
+++ b/AgentSessions/Analytics/Services/AnalyticsService.swift
@@ -21,6 +21,7 @@ final class AnalyticsService: ObservableObject {
     private let droidIndexer: DroidSessionIndexer
     private let piIndexer: PiSessionIndexer
     private let kimiIndexer: KimiSessionIndexer
+    private let grokIndexer: GrokSessionIndexer
 
     private var cancellables = Set<AnyCancellable>()
     private let repository: AnalyticsRepository?
@@ -36,7 +37,8 @@ final class AnalyticsService: ObservableObject {
          copilotIndexer: CopilotSessionIndexer,
          droidIndexer: DroidSessionIndexer,
          piIndexer: PiSessionIndexer,
-         kimiIndexer: KimiSessionIndexer) {
+         kimiIndexer: KimiSessionIndexer,
+         grokIndexer: GrokSessionIndexer) {
         self.codexIndexer = codexIndexer
         self.claudeIndexer = claudeIndexer
         self.antigravityIndexer = antigravityIndexer
@@ -46,6 +48,7 @@ final class AnalyticsService: ObservableObject {
         self.droidIndexer = droidIndexer
         self.piIndexer = piIndexer
         self.kimiIndexer = kimiIndexer
+        self.grokIndexer = grokIndexer
         if let db = try? IndexDB() {
             self.repository = AnalyticsRepository(db: db)
         } else {
@@ -96,6 +99,7 @@ final class AnalyticsService: ObservableObject {
         if AgentEnablement.isEnabled(.droid) { allSessions.append(contentsOf: droidIndexer.allSessions) }
         if AgentEnablement.isEnabled(.pi) { allSessions.append(contentsOf: piIndexer.allSessions) }
         if AgentEnablement.isEnabled(.kimi) { allSessions.append(contentsOf: kimiIndexer.allSessions) }
+        if AgentEnablement.isEnabled(.grok) { allSessions.append(contentsOf: grokIndexer.allSessions) }
 
         // Apply filters for current period
         let filtered = filterSessions(allSessions, dateRange: dateRange, agentFilter: agentFilter, projectFilter: projectFilter)
@@ -130,6 +134,7 @@ final class AnalyticsService: ObservableObject {
         if AgentEnablement.isEnabled(.droid) { allSessions.append(contentsOf: droidIndexer.allSessions) }
         if AgentEnablement.isEnabled(.pi) { allSessions.append(contentsOf: piIndexer.allSessions) }
         if AgentEnablement.isEnabled(.kimi) { allSessions.append(contentsOf: kimiIndexer.allSessions) }
+        if AgentEnablement.isEnabled(.grok) { allSessions.append(contentsOf: grokIndexer.allSessions) }
 
         // Apply message count filters (same as Sessions List)
         let hideZero = UserDefaults.standard.object(forKey: "HideZeroMessageSessions") as? Bool ?? true
@@ -744,7 +749,7 @@ final class AnalyticsService: ObservableObject {
         Publishers.CombineLatest3(
             Publishers.CombineLatest4(codexIndexer.$launchPhase, claudeIndexer.$launchPhase, antigravityIndexer.$launchPhase, opencodeIndexer.$launchPhase),
             Publishers.CombineLatest3(hermesIndexer.$launchPhase, copilotIndexer.$launchPhase, droidIndexer.$launchPhase),
-            Publishers.CombineLatest(piIndexer.$launchPhase, kimiIndexer.$launchPhase)
+            Publishers.CombineLatest3(piIndexer.$launchPhase, kimiIndexer.$launchPhase, grokIndexer.$launchPhase)
         )
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -767,7 +772,8 @@ final class AnalyticsService: ObservableObject {
                 (SessionSource.copilot, copilotIndexer.launchPhase),
                 (SessionSource.droid, droidIndexer.launchPhase),
                 (SessionSource.pi, piIndexer.launchPhase),
-                (SessionSource.kimi, kimiIndexer.launchPhase)
+                (SessionSource.kimi, kimiIndexer.launchPhase),
+                (SessionSource.grok, grokIndexer.launchPhase)
             ].filter { enabled.contains($0.0) }.map { $0.1 }
             let phasesReady = phases.allSatisfy { phase in
                 switch phase {

--- a/AgentSessions/Analytics/Utilities/AnalyticsColors.swift
+++ b/AgentSessions/Analytics/Utilities/AnalyticsColors.swift
@@ -28,6 +28,8 @@ extension Color {
     static let agentPi: Color = TranscriptColorSystem.agentBrandAccent(source: .pi)
     /// Kimi Code brand color
     static let agentKimi: Color = TranscriptColorSystem.agentBrandAccent(source: .kimi)
+    /// Grok CLI brand color
+    static let agentGrok: Color = TranscriptColorSystem.agentBrandAccent(source: .grok)
 
     // MARK: - Monochrome Support
 
@@ -43,6 +45,7 @@ extension Color {
     static let agentCursorGray = Color(white: 0.9)
     static let agentPiGray = Color(white: 0.68)
     static let agentKimiGray = Color(white: 0.66)
+    static let agentGrokGray = Color(white: 0.62)
 
     /// Get the brand color for a given session source
     static func agentColor(for source: SessionSource) -> Color {
@@ -58,6 +61,7 @@ extension Color {
         case .cursor: return .agentCursor
         case .pi: return .agentPi
         case .kimi: return .agentKimi
+        case .grok: return .agentGrok
         }
     }
 
@@ -76,6 +80,7 @@ extension Color {
             case .cursor: return .agentCursorGray
             case .pi: return .agentPiGray
             case .kimi: return .agentKimiGray
+            case .grok: return .agentGrokGray
             }
         } else {
             return agentColor(for: source)
@@ -107,6 +112,8 @@ extension Color {
             return .agentPi
         } else if lower.contains("kimi") {
             return .agentKimi
+        } else if lower.contains("grok") {
+            return .agentGrok
         } else {
             return .accentColor
         }
@@ -138,6 +145,8 @@ extension Color {
                 return .agentPiGray
             } else if lower.contains("kimi") {
                 return .agentKimiGray
+            } else if lower.contains("grok") {
+                return .agentGrokGray
             } else {
                 return .secondary
             }

--- a/AgentSessions/Analytics/Views/AnalyticsView.swift
+++ b/AgentSessions/Analytics/Views/AnalyticsView.swift
@@ -405,7 +405,8 @@ extension View {
         copilotIndexer: copilotIndexer,
         droidIndexer: DroidSessionIndexer(),
         piIndexer: PiSessionIndexer(),
-        kimiIndexer: KimiSessionIndexer()
+        kimiIndexer: KimiSessionIndexer(),
+        grokIndexer: GrokSessionIndexer()
     )
 
     AnalyticsView(service: service)

--- a/AgentSessions/Grok/GrokCLIEnvironment.swift
+++ b/AgentSessions/Grok/GrokCLIEnvironment.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+protocol GrokCLIEnvironmentProviding {
+    func probe(customPath: String?) -> Result<GrokCLIEnvironment.ProbeResult, GrokCLIEnvironment.ProbeError>
+}
+
+/// Locates and interrogates the Grok CLI.
+///
+/// Verified against `grok --help` at CLI 1.0.0 (3cd0d0cbcebe):
+///
+///     -r, --resume [<SESSION_ID_OR_TITLE>]
+///                          Resume a session by ID or title, or the most recent
+///                          if omitted.
+///     -c, --continue       Continue the most recent session for the current
+///                          working directory.
+///
+/// Homebrew also ships an unrelated `grok` *formula* (jordansissel/grok, a regex
+/// utility); the Grok CLI itself arrives as the `grok-build` *cask*. A candidate
+/// binary is therefore accepted only once its `--help` advertises the resume
+/// flags above, which the regex tool does not.
+struct GrokCLIEnvironment: GrokCLIEnvironmentProviding {
+    static let binaryName = "grok"
+
+    struct ProbeResult {
+        let versionString: String
+        let binaryURL: URL
+        let supportsResume: Bool
+        let supportsContinue: Bool
+    }
+
+    enum ProbeError: Error, LocalizedError {
+        case binaryNotFound
+        case commandFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .binaryNotFound:
+                return "Grok CLI executable not found."
+            case let .commandFailed(stderr):
+                return stderr.isEmpty ? "Failed to execute grok --version." : stderr
+            }
+        }
+    }
+
+    private let executor: CommandExecuting
+
+    init(executor: CommandExecuting = ProcessCommandExecutor()) {
+        self.executor = executor
+    }
+
+    func resolveBinary(customPath: String?) -> URL? {
+        if let customPath, !customPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let expanded = (customPath as NSString).expandingTildeInPath
+            let url = URL(fileURLWithPath: expanded)
+            return FileManager.default.isExecutableFile(atPath: url.path) ? url : nil
+        }
+
+        let loginShellCandidates = [whichViaLoginShell(Self.binaryName)].compactMap { $0 }
+        if let url = bestGrokCLI(from: loginShellCandidates) {
+            return url
+        }
+
+        let pathCandidates = [which(Self.binaryName)].compactMap { $0 }
+        if let url = bestGrokCLI(from: pathCandidates) {
+            return url
+        }
+
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidates = [
+            "\(home)/.grok/bin/\(Self.binaryName)",
+            "\(home)/.local/bin/\(Self.binaryName)",
+            "\(home)/.npm-global/bin/\(Self.binaryName)",
+            "/opt/homebrew/bin/\(Self.binaryName)",
+            "/usr/local/bin/\(Self.binaryName)"
+        ]
+
+        return bestGrokCLI(from: candidates)
+    }
+
+    func probe(customPath: String?) -> Result<ProbeResult, ProbeError> {
+        guard let binary = resolveBinary(customPath: customPath) else {
+            return .failure(.binaryNotFound)
+        }
+
+        do {
+            let versionRes = try executor.run([binary.path, "--version"], cwd: nil)
+            let versionString: String
+            if versionRes.exitCode == 0 {
+                let combined = [versionRes.stdout, versionRes.stderr]
+                    .joined(separator: "\n")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                versionString = combined.isEmpty ? "unknown" : combined
+            } else {
+                versionString = "unknown"
+            }
+
+            let helpRes = try? executor.run([binary.path, "--help"], cwd: nil)
+            let helpOut = [helpRes?.stdout, helpRes?.stderr]
+                .compactMap { $0 }
+                .joined(separator: "\n")
+
+            return .success(
+                ProbeResult(
+                    versionString: versionString,
+                    binaryURL: binary,
+                    supportsResume: helpContainsFlag("--resume", in: helpOut),
+                    supportsContinue: helpContainsFlag("--continue", in: helpOut)
+                )
+            )
+        } catch {
+            return .failure(.commandFailed(error.localizedDescription))
+        }
+    }
+
+    private func which(_ command: String) -> String? {
+        guard let path = ProcessInfo.processInfo.environment["PATH"] else { return nil }
+        for component in path.split(separator: ":") {
+            let candidate = URL(fileURLWithPath: String(component)).appendingPathComponent(command)
+            if FileManager.default.isExecutableFile(atPath: candidate.path) { return candidate.path }
+        }
+        return nil
+    }
+
+    private func whichViaLoginShell(_ command: String) -> String? {
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        do {
+            let result = try executor.run([shell, "-lic", "command -v \(command) || true"], cwd: nil)
+            let res = [result.stdout, result.stderr].joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !res.isEmpty, res != command else { return nil }
+            return res.split(whereSeparator: { $0.isNewline }).first.map(String.init)
+        } catch {
+            return nil
+        }
+    }
+
+    private func bestGrokCLI(from paths: [String]) -> URL? {
+        var firstExecutable: URL?
+        var seen = Set<String>()
+
+        for path in paths {
+            guard seen.insert(path).inserted else { continue }
+            guard FileManager.default.isExecutableFile(atPath: path) else { continue }
+            let url = URL(fileURLWithPath: path)
+            if firstExecutable == nil {
+                firstExecutable = url
+            }
+            if supportsResumeFlags(binary: url) {
+                return url
+            }
+        }
+
+        return firstExecutable
+    }
+
+    private func supportsResumeFlags(binary: URL) -> Bool {
+        let help = try? executor.run([binary.path, "--help"], cwd: nil)
+        let helpOut = [help?.stdout, help?.stderr]
+            .compactMap { $0 }
+            .joined(separator: "\n")
+        return helpContainsFlag("--resume", in: helpOut)
+            || helpContainsFlag("--continue", in: helpOut)
+    }
+
+    private func helpContainsFlag(_ flag: String, in help: String) -> Bool {
+        help.split { character in
+            character.isWhitespace || ",=[](){}<>:;".contains(character)
+        }
+        .contains { $0 == flag }
+    }
+}

--- a/AgentSessions/Grok/GrokSettings.swift
+++ b/AgentSessions/Grok/GrokSettings.swift
@@ -1,0 +1,135 @@
+import Foundation
+import SwiftUI
+
+/// Preferences backing the Grok pane.
+///
+/// Mirrors `PiSettings` minus `preferITerm` and `fallbackPolicy`, which Pi
+/// persists but never exposes in its own pane -- stored preferences with no
+/// writer are the defect class this file exists to avoid. The terminal kind
+/// comes from the shared `ResumePreferenceHelpers.resolveTerminalKind()`, and
+/// the fallback policy is a `GrokResumeCoordinator` default.
+///
+/// `defaultWorkingDirectory` is deliberately absent for a different reason:
+/// Grok's working directory is authoritative in the `state.json` sidecar, and
+/// a user-supplied default would be a *guess* that silently redirects
+/// `--continue` at an unrelated session. `GrokResumeCoordinator` refuses that
+/// strategy without a known directory instead.
+@MainActor
+final class GrokSettings: ObservableObject {
+    static let shared = GrokSettings()
+
+    enum Keys {
+        static let binaryPath = "GrokBinaryPath"
+        static let resolvedBinaryPath = "GrokResolvedBinaryPath"
+        static let resolvedSupportsResume = "GrokResolvedSupportsSession"
+        static let resolvedSupportsContinue = "GrokResolvedSupportsContinue"
+    }
+
+    @Published var binaryPath: String
+    @Published var resolvedBinaryPath: String
+    @Published var resolvedSupportsResume: Bool
+    @Published var resolvedSupportsContinue: Bool
+
+    private let defaults: UserDefaults
+
+    fileprivate init(defaults: UserDefaults = .standard, warmResolvedBinaryCache: Bool = true) {
+        self.defaults = defaults
+        binaryPath = defaults.string(forKey: Keys.binaryPath) ?? ""
+        resolvedBinaryPath = defaults.string(forKey: Keys.resolvedBinaryPath) ?? ""
+        resolvedSupportsResume = defaults.bool(forKey: Keys.resolvedSupportsResume)
+        resolvedSupportsContinue = defaults.bool(forKey: Keys.resolvedSupportsContinue)
+        if warmResolvedBinaryCache {
+            warmResolvedBinaryPathIfNeeded()
+        }
+    }
+
+    func setBinaryPath(_ path: String) {
+        binaryPath = path
+        defaults.set(path, forKey: Keys.binaryPath)
+        if path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            setResolvedBinaryPath(nil)
+            warmResolvedBinaryPathIfNeeded()
+        }
+    }
+
+    func setResolvedBinaryPath(_ path: String?) {
+        setResolvedBinary(path, supportsResume: path != nil, supportsContinue: path != nil)
+    }
+
+    func setResolvedBinary(_ path: String?, supportsResume: Bool, supportsContinue: Bool) {
+        let value = (path ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        resolvedBinaryPath = value
+        resolvedSupportsResume = !value.isEmpty && supportsResume
+        resolvedSupportsContinue = !value.isEmpty && supportsContinue
+        defaults.set(value, forKey: Keys.resolvedBinaryPath)
+        defaults.set(resolvedSupportsResume, forKey: Keys.resolvedSupportsResume)
+        defaults.set(resolvedSupportsContinue, forKey: Keys.resolvedSupportsContinue)
+    }
+
+    func hasCustomBinary() -> Bool {
+        !binaryPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// The binary and strategy the copy-resume command should use.
+    ///
+    /// A custom binary is taken at face value — the user chose it, so we do not
+    /// second-guess which flags it supports. Otherwise we prefer the probed
+    /// binary's advertised capabilities, and fall back to a bare `grok` on PATH
+    /// when nothing has been probed yet.
+    func copyCommandPlan(sessionID: String) -> (binary: String, strategy: GrokResumeCommandBuilder.Strategy)? {
+        let trimmedSessionID = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+        // One source of truth for the id-present/id-absent branch.
+        let preferredStrategy = GrokResumeCommandBuilder().strategy(forSessionID: trimmedSessionID)
+        let custom = binaryPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !custom.isEmpty {
+            return (custom, preferredStrategy)
+        }
+
+        if let cached = validatedCachedResolvedBinaryPath() {
+            if !trimmedSessionID.isEmpty, resolvedSupportsResume {
+                return (cached, .sessionByID(id: trimmedSessionID))
+            }
+            if resolvedSupportsContinue {
+                return (cached, .continueMostRecent)
+            }
+            return nil
+        }
+
+        return (GrokCLIEnvironment.binaryName, preferredStrategy)
+    }
+
+    private func warmResolvedBinaryPathIfNeeded() {
+        guard resolvedBinaryPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard binaryPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self else { return }
+            let env = GrokCLIEnvironment()
+            let result = env.probe(customPath: nil)
+            if case let .success(resolved) = result {
+                DispatchQueue.main.async { [weak self] in
+                    self?.setResolvedBinary(resolved.binaryURL.path,
+                                            supportsResume: resolved.supportsResume,
+                                            supportsContinue: resolved.supportsContinue)
+                }
+            }
+        }
+    }
+
+    private func validatedCachedResolvedBinaryPath() -> String? {
+        let cached = resolvedBinaryPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cached.isEmpty else { return nil }
+        if FileManager.default.isExecutableFile(atPath: cached) {
+            return cached
+        }
+        setResolvedBinaryPath(nil)
+        warmResolvedBinaryPathIfNeeded()
+        return nil
+    }
+}
+
+extension GrokSettings {
+    static func makeForTesting(defaults: UserDefaults = UserDefaults(suiteName: "GrokTests") ?? .standard) -> GrokSettings {
+        GrokSettings(defaults: defaults, warmResolvedBinaryCache: false)
+    }
+}

--- a/AgentSessions/GrokResume/GrokResumeCommandBuilder.swift
+++ b/AgentSessions/GrokResume/GrokResumeCommandBuilder.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Builds the shell command that reopens a Grok CLI session.
+///
+/// Verified against `grok --help` at CLI 1.0.0 (3cd0d0cbcebe):
+///
+///     -r, --resume [<SESSION_ID_OR_TITLE>]
+///                          Resume a session by ID or title, or the most recent
+///                          if omitted.
+///     -c, --continue       Continue the most recent session for the current
+///                          working directory.
+///
+/// `Session.id` is the on-disk session directory name, a bare UUIDv7 with no
+/// prefix. `--resume` documents that "UUID-shaped values always mean IDs", so
+/// passing the directory name through verbatim resolves unambiguously and never
+/// falls back to title matching.
+struct GrokResumeCommandBuilder {
+    struct CommandPackage {
+        let shellCommand: String
+        let displayCommand: String
+        let workingDirectory: URL?
+    }
+
+    enum BuildError: Error {
+        case missingSessionID
+    }
+
+    enum Strategy {
+        case sessionByID(id: String)
+        case continueMostRecent
+    }
+
+    /// Builds the launchable package for a terminal resume. The binary is a
+    /// resolved absolute path here, so it is always quoted; `makeCoreCommand`
+    /// quotes only when needed because its output is shown to the user.
+    func makeCommand(strategy: Strategy,
+                     binaryURL: URL,
+                     workingDirectory: URL?) throws -> CommandPackage {
+        let command = try makeCoreCommand(strategy: strategy,
+                                          binaryCommand: binaryURL.path,
+                                          quoteBinary: shellQuote,
+                                          quoteArgument: shellQuote)
+
+        let shell: String
+        if let wd = workingDirectory?.path, !wd.isEmpty {
+            shell = "cd \(shellQuote(wd)) && \(command)"
+        } else {
+            shell = command
+        }
+
+        return CommandPackage(shellCommand: shell, displayCommand: command, workingDirectory: workingDirectory)
+    }
+
+    func makeCoreCommand(strategy: Strategy, binaryCommand: String) throws -> String {
+        try makeCoreCommand(strategy: strategy,
+                            binaryCommand: binaryCommand,
+                            quoteBinary: shellQuoteIfNeeded,
+                            quoteArgument: shellQuoteIfNeeded)
+    }
+
+    private func makeCoreCommand(strategy: Strategy,
+                                 binaryCommand: String,
+                                 quoteBinary: (String) -> String,
+                                 quoteArgument: (String) -> String) throws -> String {
+        let invocation = quoteBinary(binaryCommand)
+        switch strategy {
+        case .sessionByID(let id):
+            let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { throw BuildError.missingSessionID }
+            return "\(invocation) --resume \(quoteArgument(trimmed))"
+        case .continueMostRecent:
+            return "\(invocation) --continue"
+        }
+    }
+
+    /// Picks `--resume <id>` when the session carries an id, else falls back to
+    /// `--continue`, which reopens the most recent session for the working
+    /// directory.
+    func strategy(forSessionID sessionID: String) -> Strategy {
+        sessionID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? .continueMostRecent
+            : .sessionByID(id: sessionID)
+    }
+
+    func shellQuote(_ string: String) -> String { ShellQuoting.quote(string) }
+    func shellQuoteIfNeeded(_ string: String) -> String { ShellQuoting.quoteIfNeeded(string) }
+}

--- a/AgentSessions/GrokResume/GrokResumeCoordinator.swift
+++ b/AgentSessions/GrokResume/GrokResumeCoordinator.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+@MainActor
+final class GrokResumeCoordinator {
+    private let env: GrokCLIEnvironmentProviding
+    private let builder: GrokResumeCommandBuilder
+    private let launcher: GrokTerminalLaunching
+
+    init(env: GrokCLIEnvironmentProviding,
+         builder: GrokResumeCommandBuilder,
+         launcher: GrokTerminalLaunching) {
+        self.env = env
+        self.builder = builder
+        self.launcher = launcher
+    }
+
+    func resumeInTerminal(input: GrokResumeInput,
+                          policy: GrokFallbackPolicy = .sessionThenContinue,
+                          dryRun: Bool = false) async -> GrokResumeResult {
+        // Probing spawns a login shell plus per-candidate --help with no
+        // timeout, so it must never run on the MainActor.
+        let env = self.env
+        let binaryOverride = input.binaryOverride
+        let probe = await Task.detached { env.probe(customPath: binaryOverride) }.value
+        guard case let .success(info) = probe else {
+            let message = probe.failureValue?.localizedDescription ?? "Grok CLI not found."
+            return GrokResumeResult(launched: false, strategy: .none, error: message, command: nil)
+        }
+
+        let hasID = (input.sessionID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+        let canResume = info.supportsResume && hasID
+        // `--continue` resumes "the previous session for the working
+        // directory", so without a known directory it resolves against
+        // whatever the terminal happens to open in and silently attaches to an
+        // unrelated session while reporting success. Refuse instead.
+        let canContinue = info.supportsContinue && input.workingDirectory != nil
+
+        let strategy: GrokResumeCommandBuilder.Strategy
+        let used: GrokStrategyUsed
+
+        if canResume {
+            strategy = .sessionByID(id: input.sessionID!)
+            used = .sessionByID
+        } else if policy == .sessionThenContinue, canContinue {
+            strategy = .continueMostRecent
+            used = .continueMostRecent
+        } else {
+            let reason: String
+            if !hasID && policy == .sessionOnly {
+                reason = "No session ID available, and fallback is disabled."
+            } else if hasID && !info.supportsResume && policy == .sessionOnly {
+                reason = "Installed Grok CLI does not support --resume."
+            } else if info.supportsContinue && input.workingDirectory == nil {
+                reason = "No working directory for this session, so --continue would resume an unrelated one."
+            } else {
+                reason = "Grok CLI does not advertise required flags (--resume/--continue)."
+            }
+            return GrokResumeResult(launched: false, strategy: .none, error: reason, command: nil)
+        }
+
+        let package: GrokResumeCommandBuilder.CommandPackage
+        do {
+            package = try builder.makeCommand(strategy: strategy,
+                                              binaryURL: info.binaryURL,
+                                              workingDirectory: input.workingDirectory)
+        } catch {
+            return GrokResumeResult(launched: false, strategy: used, error: error.localizedDescription, command: nil)
+        }
+
+        if dryRun {
+            return GrokResumeResult(launched: false, strategy: used, error: nil, command: package.shellCommand)
+        }
+
+        do {
+            try await launcher.launchInTerminal(package)
+            return GrokResumeResult(launched: true, strategy: used, error: nil, command: package.shellCommand)
+        } catch {
+            // No retry here. Nothing `launchInTerminal` throws is
+            // command-dependent: Terminal/iTerm fail only when osascript exits
+            // non-zero, and the command reaches it as an opaque argv item;
+            // Warp fails on a missing scheme handler, a directory-create or
+            // tab-config write, or a refused open -- none of them a function of
+            // which command was requested.
+            // Retrying with a *different* command cannot recover — and if it
+            // did succeed it would resume an unrelated session while reporting
+            // success.
+            return GrokResumeResult(launched: false, strategy: used, error: error.localizedDescription, command: nil)
+        }
+    }
+}
+
+private extension Result where Success == GrokCLIEnvironment.ProbeResult, Failure == GrokCLIEnvironment.ProbeError {
+    var failureValue: Failure? { if case let .failure(e) = self { return e } ; return nil }
+}

--- a/AgentSessions/GrokResume/GrokResumeTypes.swift
+++ b/AgentSessions/GrokResume/GrokResumeTypes.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// What to do when the session id cannot be used.
+///
+/// Grok exposes `--resume <id>` and `--continue`, so
+/// the only fallback is "continue the most recent session for this working
+/// directory".
+enum GrokFallbackPolicy: String {
+    case sessionThenContinue
+    case sessionOnly
+}
+
+struct GrokResumeInput {
+    var sessionID: String?
+    var workingDirectory: URL?
+    var binaryOverride: String?
+}
+
+enum GrokStrategyUsed: Equatable {
+    case sessionByID
+    case continueMostRecent
+    case none
+}
+
+struct GrokResumeResult {
+    let launched: Bool
+    let strategy: GrokStrategyUsed
+    let error: String?
+    let command: String?
+}

--- a/AgentSessions/GrokResume/GrokTerminalLauncher.swift
+++ b/AgentSessions/GrokResume/GrokTerminalLauncher.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@MainActor
+protocol GrokTerminalLaunching {
+    func launchInTerminal(_ package: GrokResumeCommandBuilder.CommandPackage) async throws
+}
+
+@MainActor
+final class GrokTerminalLauncher: GrokTerminalLaunching {
+    func launchInTerminal(_ package: GrokResumeCommandBuilder.CommandPackage) async throws {
+        try AgentTerminalLauncher.launchInTerminal(shellCommand: package.shellCommand, domain: "GrokTerminalLauncher")
+    }
+}
+
+@MainActor
+final class GrokITermLauncher: GrokTerminalLaunching {
+    func launchInTerminal(_ package: GrokResumeCommandBuilder.CommandPackage) async throws {
+        try AgentTerminalLauncher.launchInITerm(shellCommand: package.shellCommand, domain: "GrokITermLauncher")
+    }
+}
+
+@MainActor
+final class GrokWarpLauncher: GrokTerminalLaunching {
+    func launchInTerminal(_ package: GrokResumeCommandBuilder.CommandPackage) async throws {
+        try await AgentTerminalLauncher.launchInWarp(shellCommand: package.displayCommand, cwd: package.workingDirectory?.path, kind: .warp)
+    }
+}
+
+@MainActor
+final class GrokWarpPreviewLauncher: GrokTerminalLaunching {
+    func launchInTerminal(_ package: GrokResumeCommandBuilder.CommandPackage) async throws {
+        try await AgentTerminalLauncher.launchInWarp(shellCommand: package.displayCommand, cwd: package.workingDirectory?.path, kind: .warpPreview)
+    }
+}

--- a/AgentSessions/Model/Session.swift
+++ b/AgentSessions/Model/Session.swift
@@ -763,7 +763,7 @@ public struct Session: Identifiable, Equatable, Codable, Sendable {
     private var storesAuthoritativeLightweightCwd: Bool {
         switch source {
         case .antigravity, .opencode, .copilot, .openclaw, .hermes,
-             .pi, .kimi, .cursor, .claude, .droid:
+             .pi, .kimi, .grok, .cursor, .claude, .droid:
             return true
         case .codex:
             return false

--- a/AgentSessions/Model/SessionSource.swift
+++ b/AgentSessions/Model/SessionSource.swift
@@ -13,6 +13,7 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
     case cursor = "cursor"
     case pi = "pi"
     case kimi = "kimi"
+    case grok = "grok"
 
     public var displayName: String {
         switch self {
@@ -27,6 +28,7 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
         case .cursor: return "Cursor"
         case .pi: return "Pi"
         case .kimi: return "Kimi Code"
+        case .grok: return "Grok CLI"
         }
     }
 
@@ -43,6 +45,7 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
         case .cursor: return "cursorarrow.rays"
         case .pi: return "p.circle"
         case .kimi: return "k.circle"
+        case .grok: return "g.circle"
         }
     }
 
@@ -58,6 +61,7 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
         case .cursor:           return "3.2"
         case .pi:               return "3.8"
         case .kimi:             return "4.7"
+        case .grok:             return "4.8"
         }
     }
 
@@ -74,6 +78,7 @@ public enum SessionSource: String, Codable, CaseIterable, Sendable {
         case .cursor:   return "Import and search your Cursor AI sessions"
         case .pi:       return "Browse your Pi coding agent sessions"
         case .kimi:     return "Browse your Kimi Code sessions"
+        case .grok:     return "Browse your Grok CLI sessions"
         }
     }
 }

--- a/AgentSessions/Onboarding/Components/OnboardingComponents.swift
+++ b/AgentSessions/Onboarding/Components/OnboardingComponents.swift
@@ -112,6 +112,7 @@ struct AgentBadge: View {
         case .cursor: return "CR"
         case .pi: return "PI"
         case .kimi: return "KM"
+        case .grok: return "GK"
         }
     }
 }

--- a/AgentSessions/Onboarding/Components/OnboardingPalette.swift
+++ b/AgentSessions/Onboarding/Components/OnboardingPalette.swift
@@ -278,6 +278,8 @@ struct OnboardingPalette {
             return Color.agentPi
         case .kimi:
             return Color.agentKimi
+        case .grok:
+            return Color.agentGrok
         }
     }
 }

--- a/AgentSessions/Onboarding/Views/FirstRunSetupView.swift
+++ b/AgentSessions/Onboarding/Views/FirstRunSetupView.swift
@@ -20,6 +20,7 @@ struct FirstRunSetupView: View {
     let cursorIndexer: CursorSessionIndexer
     let piIndexer: PiSessionIndexer
     let kimiIndexer: KimiSessionIndexer
+    let grokIndexer: GrokSessionIndexer
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -35,6 +36,7 @@ struct FirstRunSetupView: View {
     @AppStorage(PreferencesKey.Agents.cursorEnabled) private var cursorAgentEnabled: Bool = true
     @AppStorage(PreferencesKey.Agents.piEnabled) private var piAgentEnabled: Bool = AgentEnablement.isEnabled(.pi)
     @AppStorage(PreferencesKey.Agents.kimiEnabled) private var kimiAgentEnabled: Bool = AgentEnablement.isEnabled(.kimi)
+    @AppStorage(PreferencesKey.Agents.grokEnabled) private var grokAgentEnabled: Bool = AgentEnablement.isEnabled(.grok)
 
     @AppStorage(PreferencesKey.codexUsageEnabled) private var codexUsageEnabled: Bool = false
     @AppStorage(PreferencesKey.claudeUsageEnabled) private var claudeUsageEnabled: Bool = false
@@ -104,6 +106,7 @@ struct FirstRunSetupView: View {
         .onReceive(cursorIndexer.$allSessions) { _ in handleSessionDataUpdate() }
         .onReceive(piIndexer.$allSessions) { _ in handleSessionDataUpdate() }
         .onReceive(kimiIndexer.$allSessions) { _ in handleSessionDataUpdate() }
+        .onReceive(grokIndexer.$allSessions) { _ in handleSessionDataUpdate() }
     }
 
     private var content: some View {
@@ -352,6 +355,7 @@ struct FirstRunSetupView: View {
         case .cursor: return cursorIndexer.allSessions
         case .pi: return piIndexer.allSessions
         case .kimi: return kimiIndexer.allSessions
+        case .grok: return grokIndexer.allSessions
         }
     }
 
@@ -394,6 +398,7 @@ struct FirstRunSetupView: View {
         case .cursor: return cursorAgentEnabled
         case .pi: return piAgentEnabled
         case .kimi: return kimiAgentEnabled
+        case .grok: return grokAgentEnabled
         }
     }
 
@@ -439,7 +444,7 @@ struct FirstRunSetupView: View {
 
         if hasCommandsOnlyPref {
             switch session.source {
-            case .codex, .opencode, .hermes, .copilot, .droid, .openclaw, .cursor, .pi, .kimi:
+            case .codex, .opencode, .hermes, .copilot, .droid, .openclaw, .cursor, .pi, .kimi, .grok:
                 if !session.events.isEmpty {
                     if !session.events.contains(where: { $0.kind == .tool_call }) { return false }
                 } else {

--- a/AgentSessions/Search/SearchCoordinator.swift
+++ b/AgentSessions/Search/SearchCoordinator.swift
@@ -175,6 +175,7 @@ final class SearchCoordinator: ObservableObject, @unchecked Sendable {
                includeCursor: Bool,
                includePi: Bool,
                includeKimi: Bool,
+               includeGrok: Bool,
                enableDeepScan: Bool,
                all: [Session]) {
         // Cancel any in-flight search
@@ -198,6 +199,7 @@ final class SearchCoordinator: ObservableObject, @unchecked Sendable {
             if includeCursor { set.insert(.cursor) }
             if includePi { set.insert(.pi) }
             if includeKimi { set.insert(.kimi) }
+            if includeGrok { set.insert(.grok) }
             return set
         }()
 

--- a/AgentSessions/Search/SearchIngestService.swift
+++ b/AgentSessions/Search/SearchIngestService.swift
@@ -383,6 +383,8 @@ actor SearchIngestService {
             return PiSessionParser.parseFileFull(at: url)
         case .kimi:
             return KimiSessionParser.parseFileFull(at: url)
+        case .grok:
+            return GrokSessionParser.parseFileFull(at: url)
         }
     }
 }

--- a/AgentSessions/Services/AgentEnablement.swift
+++ b/AgentSessions/Services/AgentEnablement.swift
@@ -62,6 +62,8 @@ enum AgentEnablement {
             return isAvailable(.pi, defaults: defaults)
         case .kimi:
             return isAvailable(.kimi, defaults: defaults)
+        case .grok:
+            return isAvailable(.grok, defaults: defaults)
         default:
             return true
         }
@@ -89,6 +91,7 @@ enum AgentEnablement {
         case .cursor:   return PreferencesKey.Agents.cursorEnabled
         case .pi:       return PreferencesKey.Agents.piEnabled
         case .kimi:     return PreferencesKey.Agents.kimiEnabled
+        case .grok:     return PreferencesKey.Agents.grokEnabled
         }
     }
 
@@ -194,6 +197,7 @@ enum AgentEnablement {
             setEnabledInternal(.cursor, enabled: isAvailable(.cursor, defaults: defaults), defaults: defaults)
             setEnabledInternal(.pi, enabled: isAvailable(.pi, defaults: defaults), defaults: defaults)
             setEnabledInternal(.kimi, enabled: isAvailable(.kimi, defaults: defaults), defaults: defaults)
+            setEnabledInternal(.grok, enabled: isAvailable(.grok, defaults: defaults), defaults: defaults)
         } else {
             // Cold start: avoid spawning the user's login shell (can be slow with heavy rc files).
             // Prefer filesystem availability checks and fall back to a fast PATH/common-locations probe.
@@ -208,6 +212,7 @@ enum AgentEnablement {
             let cursor = isAvailable(.cursor, defaults: defaults)
             let pi = isAvailable(.pi, defaults: defaults)
             let kimi = isAvailable(.kimi, defaults: defaults)
+            let grok = isAvailable(.grok, defaults: defaults)
 
             setEnabledInternal(.codex, enabled: codex, defaults: defaults)
             setEnabledInternal(.claude, enabled: claude, defaults: defaults)
@@ -220,6 +225,7 @@ enum AgentEnablement {
             setEnabledInternal(.cursor, enabled: cursor, defaults: defaults)
             setEnabledInternal(.pi, enabled: pi, defaults: defaults)
             setEnabledInternal(.kimi, enabled: kimi, defaults: defaults)
+            setEnabledInternal(.grok, enabled: grok, defaults: defaults)
         }
 
         // Guarantee at least one enabled agent.
@@ -283,6 +289,9 @@ enum AgentEnablement {
         case .kimi:
             let custom = defaults.string(forKey: PreferencesKey.Paths.kimiSessionsRootOverride) ?? ""
             root = KimiSessionDiscovery(customRoot: custom.isEmpty ? nil : custom).sessionsRoot()
+        case .grok:
+            let custom = defaults.string(forKey: PreferencesKey.Paths.grokSessionsRootOverride) ?? ""
+            root = GrokSessionDiscovery(customRoot: custom.isEmpty ? nil : custom).sessionsRoot()
         }
         if fm.fileExists(atPath: root.path, isDirectory: &isDir), isDir.boolValue { return true }
         if source == .droid {
@@ -322,6 +331,15 @@ enum AgentEnablement {
             return binaryDetectedCached("pi")
         case .kimi:
             return binaryDetectedCached("kimi")
+        case .grok:
+            // Homebrew also ships an unrelated `grok` formula (jordansissel/grok,
+            // a regex utility), so a bare PATH hit is not evidence of the Grok
+            // CLI. Require the CLI's own home directory alongside the binary.
+            guard binaryDetectedCached("grok") else { return false }
+            let grokHome = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".grok", isDirectory: true)
+            var isGrokHome: ObjCBool = false
+            return FileManager.default.fileExists(atPath: grokHome.path, isDirectory: &isGrokHome) && isGrokHome.boolValue
         }
     }
 
@@ -376,6 +394,8 @@ enum AgentEnablement {
             return defaults.object(forKey: PreferencesKey.piCLIAvailable) as? Bool
         case .kimi:
             return defaults.object(forKey: PreferencesKey.kimiCLIAvailable) as? Bool
+        case .grok:
+            return defaults.object(forKey: PreferencesKey.grokCLIAvailable) as? Bool
         }
     }
 

--- a/AgentSessions/Services/AgentUpdateService.swift
+++ b/AgentSessions/Services/AgentUpdateService.swift
@@ -449,6 +449,12 @@ private extension AgentUpdateService {
             return nil
         case .kimi:
             return nil
+        case .grok:
+            // No mapping on purpose. The Grok CLI ships as a Homebrew *cask*
+            // (`grok-build`), while the `grok` *formula* is an unrelated regex
+            // utility — offering that as an update path would upgrade the wrong
+            // package.
+            return nil
         }
     }
 

--- a/AgentSessions/Services/GrokSessionDiscovery.swift
+++ b/AgentSessions/Services/GrokSessionDiscovery.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Discovery for Grok CLI session stores under `~/.grok/sessions`.
+///
+/// Layout: `sessions/<percent-encoded workdir>/<sessionId>/`, where the session
+/// directory holds `summary.json` (the sidecar) alongside `chat_history.jsonl`
+/// (the transcript) and a much larger `updates.jsonl` event journal.
+///
+/// The transcript, not the journal, is the discovery unit. `updates.jsonl`
+/// carries the same conversation re-encoded as streaming ACP updates and runs
+/// three orders of magnitude larger — 2.3 GB against 1.2 MB in the largest
+/// session measured — because each `tool_call_update` repeats the whole
+/// accumulated tool output rather than a delta. Reading `chat_history.jsonl`
+/// yields the identical transcript at a fraction of the cost.
+final class GrokSessionDiscovery: SessionDiscovery {
+    private let customRoot: String?
+
+    init(customRoot: String? = nil) {
+        self.customRoot = customRoot
+    }
+
+    func sessionsRoot() -> URL {
+        if let customRoot, !customRoot.isEmpty {
+            let expanded = (customRoot as NSString).expandingTildeInPath
+            return normalizedSessionsRoot(URL(fileURLWithPath: expanded, isDirectory: true))
+        }
+        if let home = ProcessInfo.processInfo.environment["GROK_HOME"], !home.isEmpty {
+            let expanded = (home as NSString).expandingTildeInPath
+            return normalizedSessionsRoot(URL(fileURLWithPath: expanded, isDirectory: true))
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".grok", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    /// The session id is the directory holding `chat_history.jsonl`.
+    static func sessionID(forTranscript url: URL) -> String? {
+        let id = url.deletingLastPathComponent().lastPathComponent
+        return id.isEmpty ? nil : id
+    }
+
+    /// `summary.json` sits beside the transcript.
+    static func summaryFile(forTranscript url: URL) -> URL {
+        url.deletingLastPathComponent()
+            .appendingPathComponent("summary.json", isDirectory: false)
+    }
+
+    func discoverSessionFiles() -> [URL] {
+        let root = sessionsRoot()
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: root.path, isDirectory: &isDir), isDir.boolValue else {
+            return []
+        }
+
+        // Two fixed levels (workdir bucket, then session id) rather than a deep
+        // enumeration: a session directory can contain `subagents/`, `terminal/`
+        // and `compaction/` subtrees, and recursing them would surface nested
+        // transcripts as if they were top-level sessions.
+        var files: [URL] = []
+        let buckets = (try? fm.contentsOfDirectory(at: root,
+                                                   includingPropertiesForKeys: [.isDirectoryKey],
+                                                   options: [.skipsHiddenFiles])) ?? []
+        for bucket in buckets {
+            guard (try? bucket.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
+            let sessions = (try? fm.contentsOfDirectory(at: bucket,
+                                                        includingPropertiesForKeys: [.isDirectoryKey],
+                                                        options: [.skipsHiddenFiles])) ?? []
+            for session in sessions {
+                guard (try? session.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
+                let transcript = session.appendingPathComponent("chat_history.jsonl", isDirectory: false)
+                guard fm.fileExists(atPath: transcript.path) else { continue }
+                guard fm.fileExists(atPath: Self.summaryFile(forTranscript: transcript).path) else { continue }
+                guard Self.sessionID(forTranscript: transcript) != nil else { continue }
+                files.append(transcript)
+            }
+        }
+
+        return files.sorted {
+            let a = (try? $0.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+            let b = (try? $1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+            if a != b { return a > b }
+            return $0.path > $1.path
+        }
+    }
+
+    private func normalizedSessionsRoot(_ root: URL) -> URL {
+        let fm = FileManager.default
+        let candidates = [root.appendingPathComponent("sessions", isDirectory: true), root]
+        for candidate in candidates {
+            var isDir: ObjCBool = false
+            if fm.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
+                return candidate
+            }
+        }
+        return root
+    }
+}

--- a/AgentSessions/Services/GrokSessionIndexer.swift
+++ b/AgentSessions/Services/GrokSessionIndexer.swift
@@ -1,0 +1,276 @@
+import Foundation
+import Combine
+import SwiftUI
+
+final class GrokSessionIndexer: ObservableObject, SessionIndexerProtocol, @unchecked Sendable {
+    @Published private(set) var allSessions: [Session] = []
+    @Published private(set) var sessions: [Session] = []
+    @Published var isIndexing: Bool = false
+    @Published var isProcessingTranscripts: Bool = false
+    @Published var progressText: String = ""
+    @Published var filesProcessed: Int = 0
+    @Published var totalFiles: Int = 0
+    @Published var indexingError: String? = nil
+    @Published var hasEmptyDirectory: Bool = false
+    @Published var launchPhase: LaunchPhase = .idle
+    @Published var query: String = ""
+    @Published var queryDraft: String = ""
+    @Published var dateFrom: Date? = nil
+    @Published var dateTo: Date? = nil
+    @Published var selectedModel: String? = nil
+    @Published var selectedKinds: Set<SessionEventKind> = Set(SessionEventKind.allCases)
+    @Published var projectFilter: String? = nil
+    @Published var isLoadingSession: Bool = false
+    @Published var loadingSessionID: String? = nil
+    @Published var activeSearchUI: SessionIndexer.ActiveSearchUI = .none
+
+    private let transcriptCache = TranscriptCache()
+    internal var searchTranscriptCache: TranscriptCache { transcriptCache }
+
+    @AppStorage(PreferencesKey.Paths.grokSessionsRootOverride) var sessionsRootOverride: String = ""
+    @AppStorage("HideZeroMessageSessions") var hideZeroMessageSessionsPref: Bool = true { didSet { recomputeNow() } }
+    @AppStorage("HideLowMessageSessions") var hideLowMessageSessionsPref: Bool = true { didSet { recomputeNow() } }
+
+    private var discovery: GrokSessionDiscovery
+    private var lastOverride: String = ""
+    private let progressThrottler = ProgressThrottler()
+    private var cancellables = Set<AnyCancellable>()
+    private var refreshToken = UUID()
+    private var reloadingSessionIDs: Set<String> = []
+    private let reloadLock = NSLock()
+    private var lastFullReloadFileStatsBySessionID: [String: SessionFileStat] = [:]
+
+    init() {
+        let initialOverride = UserDefaults.standard.string(forKey: PreferencesKey.Paths.grokSessionsRootOverride) ?? ""
+        self.discovery = GrokSessionDiscovery(customRoot: initialOverride.isEmpty ? nil : initialOverride)
+        self.lastOverride = initialOverride
+
+        let inputs = Publishers.CombineLatest4(
+            $query.removeDuplicates(),
+            $dateFrom.removeDuplicates(by: OptionalDateEquality.eq),
+            $dateTo.removeDuplicates(by: OptionalDateEquality.eq),
+            $selectedModel.removeDuplicates()
+        )
+
+        Publishers.CombineLatest3(inputs, $selectedKinds.removeDuplicates(), $allSessions)
+            .receive(on: FeatureFlags.backgroundIngestQueue)
+            .map { [weak self] input, kinds, all -> [Session] in
+                let (q, from, to, model) = input
+                let filters = Filters(query: q,
+                                      dateFrom: from,
+                                      dateTo: to,
+                                      model: model,
+                                      kinds: kinds,
+                                      repoName: self?.projectFilter,
+                                      pathContains: nil)
+                var results = FilterEngine.filterSessions(all, filters: filters, transcriptCache: self?.transcriptCache, allowTranscriptGeneration: !FeatureFlags.filterUsesCachedTranscriptOnly)
+                if self?.hideZeroMessageSessionsPref ?? true { results = results.filter { $0.messageCount > 0 } }
+                if self?.hideLowMessageSessionsPref ?? true { results = results.filter { $0.messageCount == 0 || $0.messageCount > 2 } }
+                return results
+            }
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$sessions)
+    }
+
+    var canAccessRootDirectory: Bool {
+        let root = discovery.sessionsRoot()
+        var isDir: ObjCBool = false
+        return FileManager.default.fileExists(atPath: root.path, isDirectory: &isDir) && isDir.boolValue
+    }
+
+    func refresh(mode: IndexRefreshMode = .incremental,
+                 trigger: IndexRefreshTrigger = .manual,
+                 executionProfile: IndexRefreshExecutionProfile = .interactive) {
+        if !AgentEnablement.isEnabled(.grok) { return }
+
+        let currentOverride = UserDefaults.standard.string(forKey: PreferencesKey.Paths.grokSessionsRootOverride) ?? ""
+        if currentOverride != lastOverride {
+            discovery = GrokSessionDiscovery(customRoot: currentOverride.isEmpty ? nil : currentOverride)
+            lastOverride = currentOverride
+        }
+
+        let token = UUID()
+        refreshToken = token
+        launchPhase = .hydrating
+        isIndexing = true
+        isProcessingTranscripts = false
+        progressText = "Scanning…"
+        filesProcessed = 0
+        totalFiles = 0
+        indexingError = nil
+        hasEmptyDirectory = false
+
+        let requestedPriority: TaskPriority = executionProfile.deferNonCriticalWork ? .utility : .userInitiated
+        let prio: TaskPriority = FeatureFlags.lowerQoSForBackgroundIngest ? .utility : requestedPriority
+        Task.detached(priority: prio) { [weak self, token, executionProfile] in
+            guard let self else { return }
+
+            let config = SessionIndexingEngine.ScanConfig(
+                source: .grok,
+                discoverFiles: { self.discovery.discoverSessionFiles() },
+                parseLightweight: { GrokSessionParser.parseFile(at: $0) },
+                shouldThrottleProgress: FeatureFlags.throttleIndexingUIUpdates,
+                throttler: self.progressThrottler,
+                shouldContinue: { self.refreshToken == token },
+                workerCount: executionProfile.workerCount,
+                sliceSize: executionProfile.sliceSize,
+                interSliceYieldNanoseconds: executionProfile.interSliceYieldNanoseconds,
+                onProgress: { processed, total in
+                    Task { @MainActor [weak self] in
+                        guard let self, self.refreshToken == token else { return }
+                        self.totalFiles = total
+                        self.filesProcessed = processed
+                        self.hasEmptyDirectory = (total == 0)
+                        if processed > 0 { self.progressText = "Indexed \(processed)/\(total)" }
+                        if self.launchPhase == .hydrating { self.launchPhase = .scanning }
+                    }
+                }
+            )
+
+            let result = await SessionIndexingEngine.hydrateOrScan(config: config)
+            await MainActor.run {
+                guard self.refreshToken == token else { return }
+                self.allSessions = result.sessions
+                self.isIndexing = false
+                self.filesProcessed = self.totalFiles
+                self.progressText = "Ready"
+                self.launchPhase = .ready
+            }
+        }
+    }
+
+    func applySearch() {
+        query = queryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        recomputeNow()
+    }
+
+    func recomputeNow() {
+        let filters = Filters(query: query,
+                              dateFrom: dateFrom,
+                              dateTo: dateTo,
+                              model: selectedModel,
+                              kinds: selectedKinds,
+                              repoName: projectFilter,
+                              pathContains: nil)
+        var results = FilterEngine.filterSessions(allSessions, filters: filters, transcriptCache: transcriptCache, allowTranscriptGeneration: !FeatureFlags.filterUsesCachedTranscriptOnly)
+        if hideZeroMessageSessionsPref { results = results.filter { $0.messageCount > 0 } }
+        if hideLowMessageSessionsPref { results = results.filter { $0.messageCount == 0 || $0.messageCount > 2 } }
+        Task { @MainActor [weak self] in self?.sessions = results }
+    }
+
+    func updateSession(_ updated: Session) {
+        if let idx = allSessions.firstIndex(where: { $0.id == updated.id }) {
+            allSessions[idx] = updated
+        }
+        let filters: TranscriptFilters = .current(showTimestamps: false, showMeta: false)
+        let transcript = SessionTranscriptBuilder.buildPlainTerminalTranscript(session: updated, filters: filters, mode: .normal)
+        transcriptCache.set(updated.id, transcript: transcript)
+    }
+
+    enum ReloadReason: String {
+        case selection
+        case focusedSessionMonitor
+        case manualRefresh
+    }
+
+    func reloadSession(id: String, force: Bool = false, reason: ReloadReason = .selection) {
+        reloadLock.lock()
+        if reloadingSessionIDs.contains(id) {
+            reloadLock.unlock()
+            return
+        }
+        reloadingSessionIDs.insert(id)
+        reloadLock.unlock()
+
+        let existingSnapshot: Session? = {
+            if Thread.isMainThread {
+                return self.allSessions.first(where: { $0.id == id })
+            }
+            var session: Session?
+            DispatchQueue.main.sync {
+                session = self.allSessions.first(where: { $0.id == id })
+            }
+            return session
+        }()
+
+        let ioQueue = FeatureFlags.backgroundIngestQueue
+        ioQueue.async {
+            defer {
+                self.reloadLock.lock()
+                self.reloadingSessionIDs.remove(id)
+                self.reloadLock.unlock()
+            }
+
+            guard let existing = existingSnapshot,
+                  FileManager.default.fileExists(atPath: existing.filePath) else { return }
+
+            let hasLoadedEvents = !existing.events.isEmpty
+            if hasLoadedEvents && !force { return }
+
+            let url = URL(fileURLWithPath: existing.filePath)
+            let preParseStat = Self.fileStat(for: url)
+            self.reloadLock.lock()
+            let lastReloadStat = self.lastFullReloadFileStatsBySessionID[id]
+            self.reloadLock.unlock()
+            if force, reason != .manualRefresh, hasLoadedEvents, let preParseStat, let lastReloadStat, preParseStat == lastReloadStat {
+                return
+            }
+
+            let shouldSurfaceLoadingState = reason == .manualRefresh || !hasLoadedEvents
+            if shouldSurfaceLoadingState {
+                Task { @MainActor [weak self] in
+                    self?.isLoadingSession = true
+                    self?.loadingSessionID = id
+                }
+            }
+
+            let parsed = GrokSessionParser.parseFileFull(at: url, allowLargeFile: true) ?? existing
+            self.reloadLock.lock()
+            if let preParseStat { self.lastFullReloadFileStatsBySessionID[id] = preParseStat }
+            self.reloadLock.unlock()
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                defer {
+                    if shouldSurfaceLoadingState, self.loadingSessionID == id {
+                        self.isLoadingSession = false
+                        self.loadingSessionID = nil
+                    }
+                }
+
+                if let idx = self.allSessions.firstIndex(where: { $0.id == id }) {
+                    let current = self.allSessions[idx]
+                    let merged = Session(id: parsed.id,
+                                         source: parsed.source,
+                                         startTime: parsed.startTime ?? current.startTime,
+                                         endTime: parsed.endTime ?? current.endTime,
+                                         model: parsed.model ?? current.model,
+                                         filePath: parsed.filePath,
+                                         fileSizeBytes: parsed.fileSizeBytes ?? current.fileSizeBytes,
+                                         eventCount: max(current.eventCount, parsed.nonMetaCount),
+                                         events: parsed.events,
+                                         cwd: parsed.cwd ?? current.lightweightCwd,
+                                         repoName: current.repoName ?? parsed.repoName,
+                                         lightweightTitle: current.lightweightTitle ?? parsed.lightweightTitle,
+                                         lightweightCommands: current.lightweightCommands,
+                                         parentSessionID: parsed.parentSessionID ?? current.parentSessionID,
+                                         subagentType: parsed.subagentType ?? current.subagentType,
+                                         customTitle: parsed.customTitle ?? current.customTitle,
+                                         surface: parsed.surface ?? current.surface,
+                                         reasoningEffort: parsed.reasoningEffort ?? current.reasoningEffort)
+                    self.allSessions[idx] = merged
+                    let filters: TranscriptFilters = .current(showTimestamps: false, showMeta: false)
+                    let transcript = SessionTranscriptBuilder.buildPlainTerminalTranscript(session: merged, filters: filters, mode: .normal)
+                    self.transcriptCache.set(merged.id, transcript: transcript)
+                }
+                self.recomputeNow()
+            }
+        }
+    }
+
+    private static func fileStat(for url: URL) -> SessionFileStat? {
+        guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
+              let modified = values.contentModificationDate else { return nil }
+        return SessionFileStat(mtime: Int64(modified.timeIntervalSince1970), size: Int64(values.fileSize ?? 0))
+    }
+}

--- a/AgentSessions/Services/GrokSessionParser.swift
+++ b/AgentSessions/Services/GrokSessionParser.swift
@@ -1,0 +1,312 @@
+import Foundation
+
+/// Parses Grok CLI session directories into `Session` values.
+///
+/// A session directory holds `summary.json` (sidecar) beside
+/// `chat_history.jsonl` (transcript). The sidecar is authoritative for identity,
+/// working directory, title, model and both timestamps; the transcript carries
+/// no per-record time of its own, so every event inherits the session bounds.
+///
+/// Transcript record types, all verified against 141 real sessions at CLI
+/// version 1.0.0 (`chat_format_version: 1`):
+///
+/// - `system` — one per session, `content` is the system prompt string.
+/// - `user` — `content` is an array of parts (`text`, `image`). A `prompt_index`
+///   marks a genuine user turn; `synthetic_reason` marks an injected one, which
+///   is why title derivation skips them.
+/// - `assistant` — `content` is a plain string, with `model_id`,
+///   `model_fingerprint`, `reasoning_effort`, and an optional `tool_calls`
+///   array of `{id, name, arguments}` where `arguments` is a JSON *string*.
+/// - `reasoning` — readable rationale lives in `summary[].text`;
+///   `encrypted_content` is opaque and deliberately ignored.
+/// - `tool_result` — `content` string keyed back by `tool_call_id`, plus an
+///   optional `images` array of data URLs.
+/// - `backend_tool_call` — server-side tools (web search); the descriptor is
+///   under `kind`, and no matching `tool_result` is emitted for it.
+enum GrokSessionParser {
+    static let defaultFullParseMaxBytes = 50 * 1024 * 1024
+    private static let previewLineLimit = 200
+
+    private struct Sidecar: Decodable {
+        struct Info: Decodable {
+            let id: String?
+            let cwd: String?
+        }
+        let info: Info?
+        let sessionSummary: String?
+        let generatedTitle: String?
+        let createdAt: String?
+        let updatedAt: String?
+        let lastActiveAt: String?
+        let currentModelId: String?
+        let numChatMessages: Int?
+        let reasoningEffort: String?
+        let parentSessionId: String?
+        let gitRootDir: String?
+
+        enum CodingKeys: String, CodingKey {
+            case info
+            case sessionSummary = "session_summary"
+            case generatedTitle = "generated_title"
+            case createdAt = "created_at"
+            case updatedAt = "updated_at"
+            case lastActiveAt = "last_active_at"
+            case currentModelId = "current_model_id"
+            case numChatMessages = "num_chat_messages"
+            case reasoningEffort = "reasoning_effort"
+            case parentSessionId = "parent_session_id"
+            case gitRootDir = "git_root_dir"
+        }
+    }
+
+    static func parseFile(at url: URL) -> Session? {
+        build(url: url, lineLimit: previewLineLimit, includeEvents: false, allowLargeFile: true)
+    }
+
+    static func parseFileFull(at url: URL, allowLargeFile: Bool = false) -> Session? {
+        build(url: url, lineLimit: nil, includeEvents: true, allowLargeFile: allowLargeFile)
+    }
+
+    private static func build(url: URL, lineLimit: Int?, includeEvents: Bool, allowLargeFile: Bool) -> Session? {
+        guard let id = GrokSessionDiscovery.sessionID(forTranscript: url) else { return nil }
+
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        if !allowLargeFile, size > defaultFullParseMaxBytes { return nil }
+
+        let sidecar = readSidecar(for: url)
+        let startTime = sidecar?.createdAt.flatMap(parseDate)
+        let endTime = sidecar?.updatedAt.flatMap(parseDate) ?? sidecar?.lastActiveAt.flatMap(parseDate)
+
+        guard let lines = loadLines(url, lineLimit: lineLimit) else { return nil }
+
+        var events: [SessionEvent] = []
+        var nonMetaCount = 0
+        var commandCount = 0
+        var firstPromptText: String?
+        var assistantModel: String?
+
+        for (index, line) in lines.enumerated() {
+            guard let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let type = object["type"] as? String else { continue }
+
+            if assistantModel == nil, let m = object["model_id"] as? String, !m.isEmpty {
+                assistantModel = m
+            }
+            if firstPromptText == nil, type == "user", isGenuinePrompt(object) {
+                firstPromptText = textContent(from: object["content"])
+            }
+
+            let built = makeEvents(type: type, object: object, time: startTime, line: line, index: index)
+            nonMetaCount += built.filter { $0.kind != .meta }.count
+            commandCount += built.filter { $0.kind == .tool_call }.count
+            if includeEvents { events.append(contentsOf: built) }
+        }
+
+        let cwd = sidecar?.info?.cwd ?? sidecar?.gitRootDir
+        let title = firstNonEmpty(sidecar?.generatedTitle, sidecar?.sessionSummary, firstPromptText)
+
+        // The sidecar counts the whole transcript, so prefer it over a preview
+        // pass that stopped at `previewLineLimit` and would otherwise report a
+        // truncated event count for every row in the list.
+        let eventCount = includeEvents ? nonMetaCount : (sidecar?.numChatMessages ?? nonMetaCount)
+
+        return Session(id: id,
+                       source: .grok,
+                       startTime: startTime,
+                       endTime: endTime,
+                       model: sidecar?.currentModelId ?? assistantModel,
+                       filePath: url.path,
+                       fileSizeBytes: size,
+                       eventCount: eventCount,
+                       events: events,
+                       cwd: cwd,
+                       repoName: cwd.map { URL(fileURLWithPath: $0).lastPathComponent },
+                       lightweightTitle: title,
+                       // nil, not 0: the preview stops at `previewLineLimit`, so
+                       // a zero means "none in the first N lines", not "none".
+                       // A stored 0 short-circuits SearchCoordinator.shouldDeepScan
+                       // ahead of its event count. Matches Kimi and OpenCode.
+                       lightweightCommands: commandCount > 0 ? commandCount : nil,
+                       parentSessionID: sidecar?.parentSessionId,
+                       surface: .cli,
+                       reasoningEffort: sidecar?.reasoningEffort)
+    }
+
+    /// A genuine user turn carries `prompt_index`. Records with
+    /// `synthetic_reason` are injected by the CLI (interrupt notices, context
+    /// re-priming) and must not become the session title.
+    private static func isGenuinePrompt(_ object: [String: Any]) -> Bool {
+        if object["synthetic_reason"] != nil { return false }
+        return object["prompt_index"] != nil
+    }
+
+    private static func loadLines(_ url: URL, lineLimit: Int?) -> [String]? {
+        guard let lineLimit else {
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+            return contents.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        }
+
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        var lines: [String] = []
+        var buffer = Data()
+        let newline = Data([0x0A])
+
+        while lines.count < lineLimit {
+            let chunk = (try? handle.read(upToCount: 64 * 1024)) ?? Data()
+            if chunk.isEmpty { break }
+            buffer.append(chunk)
+
+            while lines.count < lineLimit, let range = buffer.range(of: newline) {
+                let lineData = buffer.subdata(in: buffer.startIndex..<range.lowerBound)
+                buffer = Data(buffer[range.upperBound..<buffer.endIndex])
+                if lineData.isEmpty { continue }
+                if let line = String(data: lineData, encoding: .utf8) { lines.append(line) }
+            }
+        }
+
+        if lines.count < lineLimit, !buffer.isEmpty,
+           let line = String(data: buffer, encoding: .utf8), !line.isEmpty {
+            lines.append(line)
+        }
+        return lines
+    }
+
+    private static func readSidecar(for url: URL) -> Sidecar? {
+        let path = GrokSessionDiscovery.summaryFile(forTranscript: url)
+        guard let data = try? Data(contentsOf: path) else { return nil }
+        return try? JSONDecoder().decode(Sidecar.self, from: data)
+    }
+
+    private static func makeEvents(type: String,
+                                   object: [String: Any],
+                                   time: Date?,
+                                   line: String,
+                                   index: Int) -> [SessionEvent] {
+        switch type {
+        case "user":
+            let text = textContent(from: object["content"])
+            return [SessionEvent(id: "\(index)-u", timestamp: time, kind: .user, role: "user", text: text,
+                                 toolName: nil, toolInput: nil, toolOutput: nil,
+                                 messageID: nil, parentID: nil, isDelta: false, rawJSON: line)]
+
+        case "assistant":
+            var out: [SessionEvent] = []
+            if let text = object["content"] as? String, !text.isEmpty {
+                out.append(SessionEvent(id: "\(index)-a", timestamp: time, kind: .assistant, role: "assistant", text: text,
+                                        toolName: nil, toolInput: nil, toolOutput: nil,
+                                        messageID: nil, parentID: nil, isDelta: false, rawJSON: line))
+            }
+            let calls = object["tool_calls"] as? [[String: Any]] ?? []
+            for (callIndex, call) in calls.enumerated() {
+                out.append(SessionEvent(id: "\(index)-t\(callIndex)", timestamp: time, kind: .tool_call, role: "assistant", text: nil,
+                                        toolName: call["name"] as? String,
+                                        // `arguments` is already a JSON string on the wire.
+                                        toolInput: call["arguments"] as? String,
+                                        toolOutput: nil,
+                                        messageID: call["id"] as? String, parentID: nil, isDelta: false, rawJSON: line))
+            }
+            if out.isEmpty { out.append(meta(index: index, suffix: "-m", role: "assistant", text: nil, time: time, line: line)) }
+            return out
+
+        case "tool_result":
+            return [SessionEvent(id: "\(index)-r", timestamp: time, kind: .tool_result, role: "tool", text: nil,
+                                 toolName: nil, toolInput: nil,
+                                 toolOutput: object["content"] as? String,
+                                 messageID: object["tool_call_id"] as? String,
+                                 parentID: nil, isDelta: false, rawJSON: line)]
+
+        case "reasoning":
+            // Readable rationale is the summary text; `encrypted_content` is an
+            // opaque server blob. Rendered as meta with a `thinking` role, the
+            // same shape Pi uses for its thinking blocks.
+            guard let text = summaryText(from: object["summary"]), !text.isEmpty else {
+                return [meta(index: index, suffix: "-m", role: "thinking", text: nil, time: time, line: line)]
+            }
+            return [meta(index: index, suffix: "-think", role: "thinking", text: "[thinking] \(text)", time: time, line: line)]
+
+        case "backend_tool_call":
+            // Server-side tool (web search). The descriptor is the payload; no
+            // separate tool_result record accompanies it.
+            let kind = object["kind"] as? [String: Any]
+            return [SessionEvent(id: "\(index)-b", timestamp: time, kind: .tool_call, role: "assistant", text: nil,
+                                 toolName: kind?["tool_type"] as? String ?? "backend_tool",
+                                 toolInput: jsonString(kind?["action"]),
+                                 toolOutput: nil,
+                                 messageID: nil, parentID: nil, isDelta: false, rawJSON: line)]
+
+        case "system":
+            return [meta(index: index, suffix: "-s", role: "system", text: object["content"] as? String, time: time, line: line)]
+
+        default:
+            return [meta(index: index, suffix: "-m", role: type, text: nil, time: time, line: line)]
+        }
+    }
+
+    private static func meta(index: Int, suffix: String, role: String?, text: String?, time: Date?, line: String) -> SessionEvent {
+        SessionEvent(id: "\(index)\(suffix)", timestamp: time, kind: .meta, role: role, text: text,
+                     toolName: nil, toolInput: nil, toolOutput: nil,
+                     messageID: nil, parentID: nil, isDelta: false, rawJSON: line)
+    }
+
+    /// User `content` is an array of parts; assistant `content` is a bare string.
+    private static func textContent(from content: Any?) -> String? {
+        if let string = content as? String { return string.isEmpty ? nil : string }
+        guard let parts = content as? [[String: Any]] else { return nil }
+        let chunks: [String] = parts.compactMap { part in
+            switch part["type"] as? String {
+            case "text": return part["text"] as? String
+            case "image": return "[image]"
+            default: return nil
+            }
+        }
+        let joined = chunks.joined(separator: "\n")
+        return joined.isEmpty ? nil : joined
+    }
+
+    private static func summaryText(from value: Any?) -> String? {
+        guard let parts = value as? [[String: Any]] else { return nil }
+        let chunks = parts.compactMap { $0["text"] as? String }
+        let joined = chunks.joined(separator: "\n")
+        return joined.isEmpty ? nil : joined
+    }
+
+    private static func jsonString(_ value: Any?) -> String? {
+        guard let value else { return nil }
+        if let string = value as? String { return string }
+        guard JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]) else { return nil }
+        if data.count > 32_768 {
+            return "[OMITTED large JSON payload bytes=\(data.count)]"
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func firstNonEmpty(_ values: String?...) -> String? {
+        for value in values {
+            if let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return value }
+        }
+        return nil
+    }
+
+    /// Sidecar timestamps are RFC 3339 with six fractional digits
+    /// ("2026-07-31T10:13:27.574131Z"); the no-fraction formatter is the
+    /// fallback for any field that omits them.
+    private static func parseDate(_ value: String) -> Date? {
+        isoFracFormatter.date(from: value) ?? isoNoFracFormatter.date(from: value)
+    }
+
+    private static let isoFracFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let isoNoFracFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+}

--- a/AgentSessions/Services/SessionArchiveManager.swift
+++ b/AgentSessions/Services/SessionArchiveManager.swift
@@ -469,6 +469,14 @@ final class SessionArchiveManager: ObservableObject, @unchecked Sendable {
                     map[id] = url
                 }
             }
+        case .grok:
+            let custom = defaults.string(forKey: PreferencesKey.Paths.grokSessionsRootOverride)
+            let discovery = GrokSessionDiscovery(customRoot: custom?.isEmpty == false ? custom : nil)
+            for url in discovery.discoverSessionFiles() {
+                if let id = GrokSessionDiscovery.sessionID(forTranscript: url) {
+                    map[id] = url
+                }
+            }
         }
 
         return map
@@ -500,6 +508,8 @@ final class SessionArchiveManager: ObservableObject, @unchecked Sendable {
             return PiSessionParser.parseFile(at: upstreamURL) ?? minimalSession(source: source, id: sessionID, url: upstreamURL)
         case .kimi:
             return KimiSessionParser.parseFileFull(at: upstreamURL) ?? minimalSession(source: source, id: sessionID, url: upstreamURL)
+        case .grok:
+            return GrokSessionParser.parseFileFull(at: upstreamURL) ?? minimalSession(source: source, id: sessionID, url: upstreamURL)
         }
     }
 

--- a/AgentSessions/Services/TranscriptColorSystem.swift
+++ b/AgentSessions/Services/TranscriptColorSystem.swift
@@ -102,6 +102,10 @@ enum TranscriptColorSystem {
         case .kimi:
             // Indigo-violet accent, distinct from Codex's blue and OpenCode's purple.
             return adaptiveBrand(NSColor(calibratedRed: 0.46, green: 0.34, blue: 0.82, alpha: 1.0))
+        case .grok:
+            // Slate blue-grey, echoing xAI's monochrome mark while staying clear
+            // of Codex's deep blue and Cursor's teal.
+            return adaptiveBrand(NSColor(calibratedRed: 0.35, green: 0.40, blue: 0.52, alpha: 1.0))
         }
     }
 

--- a/AgentSessions/Services/UnifiedSessionIndexer.swift
+++ b/AgentSessions/Services/UnifiedSessionIndexer.swift
@@ -78,7 +78,8 @@ final class UnifiedSessionIndexer: ObservableObject {
         .openclaw: defaultFocusedSessionRefreshIntervals,
         .cursor: defaultFocusedSessionRefreshIntervals,
         .pi: defaultFocusedSessionRefreshIntervals,
-        .kimi: defaultFocusedSessionRefreshIntervals
+        .kimi: defaultFocusedSessionRefreshIntervals,
+        .grok: defaultFocusedSessionRefreshIntervals
     ]
     private struct FileSignature: Equatable {
         let path: String
@@ -323,6 +324,26 @@ final class UnifiedSessionIndexer: ObservableObject {
                 }
                 indexer.kimi.reloadSession(id: context.sessionID, force: force, reason: reason)
             }
+        ),
+        .grok: FocusedMonitorCapability(
+            supportsFocusedMonitoring: { true },
+            signatureSource: { indexer, context in
+                indexer.sourceAwareFocusedSignaturePath(for: context)
+            },
+            reloadFocusedSession: { indexer, context, trigger in
+                guard indexer.grokAgentEnabled else { return }
+                let force = (trigger != .selection)
+                let reason: GrokSessionIndexer.ReloadReason
+                switch trigger {
+                case .selection:
+                    reason = .selection
+                case .monitor:
+                    reason = .focusedSessionMonitor
+                case .manual:
+                    reason = .manualRefresh
+                }
+                indexer.grok.reloadSession(id: context.sessionID, force: force, reason: reason)
+            }
         )
     ]
 
@@ -425,6 +446,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         let cursor: Bool
         let pi: Bool
         let kimi: Bool
+        let grok: Bool
     }
 
     struct SessionAggregationWork {
@@ -439,6 +461,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         let cursorList: [Session]
         let piList: [Session]
         let kimiList: [Session]
+        let grokList: [Session]
         let favoritesSnapshot: FavoritesStore.Snapshot
         let favoritesVersion: UInt64
         let enablement: AgentEnablementSnapshot
@@ -455,6 +478,7 @@ final class UnifiedSessionIndexer: ObservableObject {
             cursorList: [],
             piList: [],
             kimiList: [],
+            grokList: [],
             favoritesSnapshot: FavoritesStore.Snapshot(legacyIDs: [], scopedKeys: []),
             favoritesVersion: 0,
             enablement: AgentEnablementSnapshot(
@@ -468,7 +492,8 @@ final class UnifiedSessionIndexer: ObservableObject {
                 openClaw: false,
                 cursor: false,
                 pi: false,
-                kimi: false
+                kimi: false,
+                grok: false
             )
         )
     }
@@ -630,6 +655,12 @@ final class UnifiedSessionIndexer: ObservableObject {
             recomputeNow()
         }
     }
+    @Published var includeGrok: Bool = UserDefaults.standard.object(forKey: "IncludeGrokSessions") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(includeGrok, forKey: "IncludeGrokSessions")
+            recomputeNow()
+        }
+    }
 
     // Global agent enablement (drives app-wide availability)
     @Published private(set) var codexAgentEnabled: Bool = AgentEnablement.isEnabled(.codex)
@@ -643,6 +674,7 @@ final class UnifiedSessionIndexer: ObservableObject {
     @Published private(set) var cursorAgentEnabled: Bool = AgentEnablement.isEnabled(.cursor)
     @Published private(set) var piAgentEnabled: Bool = AgentEnablement.isEnabled(.pi)
     @Published private(set) var kimiAgentEnabled: Bool = AgentEnablement.isEnabled(.kimi)
+    @Published private(set) var grokAgentEnabled: Bool = AgentEnablement.isEnabled(.grok)
 
     /// Providers detected on disk that the user hasn't been notified about yet.
     @Published private(set) var newlyAvailableProviders: [SessionSource] = []
@@ -685,6 +717,7 @@ final class UnifiedSessionIndexer: ObservableObject {
     private let cursor: CursorSessionIndexer
     private let pi: PiSessionIndexer
     private let kimi: KimiSessionIndexer
+    private let grok: GrokSessionIndexer
     private static let aggregationQueue = DispatchQueue(label: "UnifiedSessionIndexer.Aggregation", qos: .userInitiated)
     private var cancellables = Set<AnyCancellable>()
     private var notificationObserverTokens: [NSObjectProtocol] = []
@@ -755,7 +788,8 @@ final class UnifiedSessionIndexer: ObservableObject {
          openclawIndexer: OpenClawSessionIndexer,
          cursorIndexer: CursorSessionIndexer,
          piIndexer: PiSessionIndexer,
-         kimiIndexer: KimiSessionIndexer) {
+         kimiIndexer: KimiSessionIndexer,
+         grokIndexer: GrokSessionIndexer) {
         self.codex = codexIndexer
         self.claude = claudeIndexer
         self.antigravity = antigravityIndexer
@@ -767,6 +801,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         self.cursor = cursorIndexer
         self.pi = piIndexer
         self.kimi = kimiIndexer
+        self.grok = grokIndexer
         self.searchIngestService = (try? IndexDB()).map { SearchIngestService(db: $0) }
         self.analyticsLastBuiltAt = UserDefaults.standard.object(forKey: Self.analyticsLastBuiltAtDefaultsKey) as? Date
 
@@ -801,6 +836,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         )
         .combineLatest($piAgentEnabled)
         .combineLatest($kimiAgentEnabled)
+        .combineLatest($grokAgentEnabled)
 
         // Merge underlying allSessions whenever any changes
         Publishers.CombineLatest(
@@ -812,17 +848,20 @@ final class UnifiedSessionIndexer: ObservableObject {
         )
             .combineLatest(pi.$allSessions)
             .combineLatest(kimi.$allSessions)
+            .combineLatest(grok.$allSessions)
             .combineLatest(agentEnabledFlags, favoritesAggregationVersion)
             .receive(on: DispatchQueue.main)
             .map { [weak self] sourceLists, flags, favoritesVersion -> SessionAggregationWork in
                 guard let self else { return .empty }
-                let (sourceListsWithPi, kimiList) = sourceLists
+                let (sourceListsWithKimi, grokList) = sourceLists
+                let (sourceListsWithPi, kimiList) = sourceListsWithKimi
                 let (sourceListsBase, piList) = sourceListsWithPi
                 let (combined, tail) = sourceListsBase
                 let (codexList, claudeList, antigravityList, opencodeList) = combined
                 let (hermesList, tailLists) = tail
                 let (copilotList, droidList, openclawList, cursorList) = tailLists
-                let (baseFlagsWithPi, kimiEnabled) = flags
+                let (baseFlagsWithKimi, grokEnabled) = flags
+                let (baseFlagsWithPi, kimiEnabled) = baseFlagsWithKimi
                 let (baseFlags, piEnabled) = baseFlagsWithPi
                 let (enabled4, enabledTail) = baseFlags
                 let (codexEnabled, claudeEnabled, antigravityEnabled, openCodeEnabled) = enabled4
@@ -840,6 +879,7 @@ final class UnifiedSessionIndexer: ObservableObject {
                     cursorList: cursorList,
                     piList: piList,
                     kimiList: kimiList,
+                    grokList: grokList,
                     favoritesSnapshot: self.favorites.snapshot(),
                     favoritesVersion: favoritesVersion,
                     enablement: AgentEnablementSnapshot(
@@ -853,7 +893,8 @@ final class UnifiedSessionIndexer: ObservableObject {
                         openClaw: openClawEnabled,
                         cursor: cursorEnabled,
                         pi: piEnabled,
-                        kimi: kimiEnabled
+                        kimi: kimiEnabled,
+                        grok: grokEnabled
                     )
                 )
             }
@@ -882,21 +923,24 @@ final class UnifiedSessionIndexer: ObservableObject {
         )
             .combineLatest(pi.$isIndexing)
             .combineLatest(kimi.$isIndexing)
+        .combineLatest(grok.$isIndexing)
             .combineLatest(agentEnabledFlags)
             .map { states, flags in
-                let (statesWithPi, kimiState) = states
+                let (statesWithKimi, grokState) = states
+                let (statesWithPi, kimiState) = statesWithKimi
                 let (baseStates, piState) = statesWithPi
                 let (s4, statesTail) = baseStates
                 let (c, cl, g, o) = s4
                 let (hermesState, tailStates) = statesTail
                 let (copilotState, droidState, openclawState, cursorState) = tailStates
-                let (baseFlagsWithPi, kimiEnabled) = flags
+                let (baseFlagsWithKimi, grokEnabled) = flags
+                let (baseFlagsWithPi, kimiEnabled) = baseFlagsWithKimi
                 let (baseFlags, piEnabled) = baseFlagsWithPi
                 let (f4, flagsTail) = baseFlags
                 let (ec, ecl, eg, eo) = f4
                 let (eHermes, tailFlags) = flagsTail
                 let (eCopilot, eDroid, eOpenClaw, eCursor) = tailFlags
-                return (ec && c) || (ecl && cl) || (eg && g) || (eo && o) || (eHermes && hermesState) || (eCopilot && copilotState) || (eDroid && droidState) || (eOpenClaw && openclawState) || (eCursor && cursorState) || (piEnabled && piState) || (kimiEnabled && kimiState)
+                return (ec && c) || (ecl && cl) || (eg && g) || (eo && o) || (eHermes && hermesState) || (eCopilot && copilotState) || (eDroid && droidState) || (eOpenClaw && openclawState) || (eCursor && cursorState) || (piEnabled && piState) || (kimiEnabled && kimiState) || (grokEnabled && grokState)
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
@@ -918,33 +962,35 @@ final class UnifiedSessionIndexer: ObservableObject {
                     hermes.$filesProcessed,
                     Publishers.CombineLatest4(copilot.$filesProcessed, droid.$filesProcessed, openclaw.$filesProcessed, cursor.$filesProcessed)
                 )
-            ).combineLatest(pi.$filesProcessed).combineLatest(kimi.$filesProcessed),
+            ).combineLatest(pi.$filesProcessed).combineLatest(kimi.$filesProcessed).combineLatest(grok.$filesProcessed),
             Publishers.CombineLatest(
                 Publishers.CombineLatest4(codex.$totalFiles, claude.$totalFiles, antigravity.$totalFiles, opencode.$totalFiles),
                 Publishers.CombineLatest(
                     hermes.$totalFiles,
                     Publishers.CombineLatest4(copilot.$totalFiles, droid.$totalFiles, openclaw.$totalFiles, cursor.$totalFiles)
                 )
-            ).combineLatest(pi.$totalFiles).combineLatest(kimi.$totalFiles),
+            ).combineLatest(pi.$totalFiles).combineLatest(kimi.$totalFiles).combineLatest(grok.$totalFiles),
             Publishers.CombineLatest(
                 Publishers.CombineLatest4(codex.$isIndexing, claude.$isIndexing, antigravity.$isIndexing, opencode.$isIndexing),
                 Publishers.CombineLatest(
                     hermes.$isIndexing,
                     Publishers.CombineLatest4(copilot.$isIndexing, droid.$isIndexing, openclaw.$isIndexing, cursor.$isIndexing)
                 )
-            ).combineLatest(pi.$isIndexing).combineLatest(kimi.$isIndexing)
+            ).combineLatest(pi.$isIndexing).combineLatest(kimi.$isIndexing).combineLatest(grok.$isIndexing)
         )
         .combineLatest(agentEnabledFlags)
         .map { metrics, flags in
-            let (baseFlagsWithPi, kimiEnabled) = flags
+            let (baseFlagsWithKimi, grokEnabled) = flags
+            let (baseFlagsWithPi, kimiEnabled) = baseFlagsWithKimi
             let (baseFlags, piEnabled) = baseFlagsWithPi
             let (processed, totals, indexing) = metrics
-            let ((processedBase, piProcessed), kimiProcessed) = processed
-            let ((totalsBase, piTotal), kimiTotal) = totals
-            let ((indexingBase, piIndexing), kimiIndexing) = indexing
+            let (((processedBase, piProcessed), kimiProcessed), grokProcessed) = processed
+            let (((totalsBase, piTotal), kimiTotal), grokTotal) = totals
+            let (((indexingBase, piIndexing), kimiIndexing), grokIndexing) = indexing
             var snapshots = Self.coreProviderSnapshots(metrics: (processedBase, totalsBase, indexingBase), flags: baseFlags)
             snapshots.append(CoreProviderSnapshot(source: .pi, enabled: piEnabled, indexing: piIndexing, processed: piProcessed, total: piTotal))
             snapshots.append(CoreProviderSnapshot(source: .kimi, enabled: kimiEnabled, indexing: kimiIndexing, processed: kimiProcessed, total: kimiTotal))
+            snapshots.append(CoreProviderSnapshot(source: .grok, enabled: grokEnabled, indexing: grokIndexing, processed: grokProcessed, total: grokTotal))
             return Self.aggregateProgress(from: snapshots)
         }
         .receive(on: DispatchQueue.main)
@@ -965,21 +1011,24 @@ final class UnifiedSessionIndexer: ObservableObject {
         )
             .combineLatest(pi.$isProcessingTranscripts)
             .combineLatest(kimi.$isProcessingTranscripts)
+        .combineLatest(grok.$isProcessingTranscripts)
             .combineLatest(agentEnabledFlags)
             .map { states, flags in
-                let (statesWithPi, kimiState) = states
+                let (statesWithKimi, grokState) = states
+                let (statesWithPi, kimiState) = statesWithKimi
                 let (baseStates, piState) = statesWithPi
                 let (s4, statesTail) = baseStates
                 let (c, cl, g, o) = s4
                 let (hermesState, tailStates) = statesTail
                 let (copilotState, droidState, openclawState, cursorState) = tailStates
-                let (baseFlagsWithPi, kimiEnabled) = flags
+                let (baseFlagsWithKimi, grokEnabled) = flags
+                let (baseFlagsWithPi, kimiEnabled) = baseFlagsWithKimi
                 let (baseFlags, piEnabled) = baseFlagsWithPi
                 let (f4, flagsTail) = baseFlags
                 let (ec, ecl, eg, eo) = f4
                 let (eHermes, tailFlags) = flagsTail
                 let (eCopilot, eDroid, eOpenClaw, eCursor) = tailFlags
-                return (ec && c) || (ecl && cl) || (eg && g) || (eo && o) || (eHermes && hermesState) || (eCopilot && copilotState) || (eDroid && droidState) || (eOpenClaw && openclawState) || (eCursor && cursorState) || (piEnabled && piState) || (kimiEnabled && kimiState)
+                return (ec && c) || (ecl && cl) || (eg && g) || (eo && o) || (eHermes && hermesState) || (eCopilot && copilotState) || (eDroid && droidState) || (eOpenClaw && openclawState) || (eCursor && cursorState) || (piEnabled && piState) || (kimiEnabled && kimiState) || (grokEnabled && grokState)
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
@@ -1011,14 +1060,17 @@ final class UnifiedSessionIndexer: ObservableObject {
         )
         .combineLatest(pi.$indexingError)
         .combineLatest(kimi.$indexingError)
+        .combineLatest(grok.$indexingError)
         let indexingErrorFlags = agentEnabledFlags.eraseToAnyPublisher()
         indexingErrors
             .combineLatest(indexingErrorFlags)
             .map { errs, flags in
-                let (errorsWithPi, kimiError) = errs
+                let (errorsWithKimi, grokError) = errs
+                let (errorsWithPi, kimiError) = errorsWithKimi
                 let (baseErrors, piError) = errorsWithPi
                 let (errs4, errsTail) = baseErrors
-                let (baseFlagsWithPi, kimiEnabled) = flags
+                let (baseFlagsWithKimi, grokEnabled) = flags
+                let (baseFlagsWithPi, kimiEnabled) = baseFlagsWithKimi
                 let (baseFlags, piEnabled) = baseFlagsWithPi
                 let (f4, flagsTail) = baseFlags
                 return Self.firstEnabledIndexingError(
@@ -1026,7 +1078,7 @@ final class UnifiedSessionIndexer: ObservableObject {
                     tailErrors: errsTail,
                     headFlags: f4,
                     tailFlags: flagsTail
-                ) ?? (piEnabled ? piError : nil) ?? (kimiEnabled ? kimiError : nil)
+                ) ?? (piEnabled ? piError : nil) ?? (kimiEnabled ? kimiError : nil) ?? (grokEnabled ? grokError : nil)
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
@@ -1052,6 +1104,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         )
         .combineLatest($includePi)
         .combineLatest($includeKimi)
+        .combineLatest($includeGrok)
         Publishers.CombineLatest4(inputs, $selectedKinds.removeDuplicates(), $allSessions, includes.combineLatest(agentEnabledFlags))
             .receive(on: FeatureFlags.backgroundIngestQueue)
             .map { [weak self] combined -> [Session] in
@@ -1059,13 +1112,15 @@ final class UnifiedSessionIndexer: ObservableObject {
                 let (input, kinds, all, combinedFlags) = combined
                 let (q, from, to, model) = input
                 let (sources, enabledFlags) = combinedFlags
-                let (sourcesWithPi, incKimi) = sources
+                let (sourcesWithKimi, incGrok) = sources
+                let (sourcesWithPi, incKimi) = sourcesWithKimi
                 let (baseSources, incPi) = sourcesWithPi
                 let (src4, tailSources) = baseSources
                 let (incCodex, incClaude, incAntigravity, incOpenCode) = src4
                 let (incHermes, sourcesTail) = tailSources
                 let (incCopilot, incDroid, incOpenClaw, incCursor) = sourcesTail
-                let (baseEnabledWithPi, enKimi) = enabledFlags
+                let (baseEnabledWithKimi, enGrok) = enabledFlags
+                let (baseEnabledWithPi, enKimi) = baseEnabledWithKimi
                 let (baseEnabled, enPi) = baseEnabledWithPi
                 let (en4, enabledTail) = baseEnabled
                 let (enCodex, enClaude, enAntigravity, enOpenCode) = en4
@@ -1082,10 +1137,11 @@ final class UnifiedSessionIndexer: ObservableObject {
                 let effectiveCursor = incCursor && enCursor
                 let effectivePi = incPi && enPi
                 let effectiveKimi = incKimi && enKimi
+                let effectiveGrok = incGrok && enGrok
 
                 // Start from all sessions, then apply the same filters we use elsewhere.
                 var base = all
-                if !(effectiveCodex && effectiveClaude && effectiveAntigravity && effectiveOpenCode && effectiveHermes && effectiveCopilot && effectiveDroid && effectiveOpenClaw && effectiveCursor && effectivePi && effectiveKimi) {
+                if !(effectiveCodex && effectiveClaude && effectiveAntigravity && effectiveOpenCode && effectiveHermes && effectiveCopilot && effectiveDroid && effectiveOpenClaw && effectiveCursor && effectivePi && effectiveKimi && effectiveGrok) {
                     base = base.filter { s in
                         (s.source == .codex && effectiveCodex) ||
                         (s.source == .claude && effectiveClaude) ||
@@ -1097,7 +1153,8 @@ final class UnifiedSessionIndexer: ObservableObject {
                         (s.source == .openclaw && effectiveOpenClaw) ||
                         (s.source == .cursor && effectiveCursor) ||
                         (s.source == .pi && effectivePi) ||
-                        (s.source == .kimi && effectiveKimi)
+                        (s.source == .kimi && effectiveKimi) ||
+                        (s.source == .grok && effectiveGrok)
                     }
                 }
 
@@ -1203,6 +1260,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         )
             .combineLatest($includePi)
             .combineLatest($includeKimi)
+        .combineLatest($includeGrok)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateLaunchState()
@@ -1257,6 +1315,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         case .cursor: return cursorAgentEnabled
         case .pi: return piAgentEnabled
         case .kimi: return kimiAgentEnabled
+        case .grok: return grokAgentEnabled
         }
     }
 
@@ -1274,6 +1333,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         let c9 = AgentEnablement.isEnabled(.cursor, defaults: defaults)
         let c10 = AgentEnablement.isEnabled(.pi, defaults: defaults)
         let c11 = AgentEnablement.isEnabled(.kimi, defaults: defaults)
+        let c12 = AgentEnablement.isEnabled(.grok, defaults: defaults)
         if c1 != codexAgentEnabled { codexAgentEnabled = c1 }
         if c2 != claudeAgentEnabled { claudeAgentEnabled = c2 }
         if c3 != antigravityAgentEnabled { antigravityAgentEnabled = c3 }
@@ -1285,6 +1345,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         if c9 != cursorAgentEnabled { cursorAgentEnabled = c9 }
         if c10 != piAgentEnabled { piAgentEnabled = c10 }
         if c11 != kimiAgentEnabled { kimiAgentEnabled = c11 }
+        if c12 != grokAgentEnabled { grokAgentEnabled = c12 }
 
         let afterSources = enabledAnalyticsSources()
         if analyticsLastBuiltAt != nil && !afterSources.subtracting(beforeSources).isEmpty {
@@ -1337,7 +1398,8 @@ final class UnifiedSessionIndexer: ObservableObject {
             openClawAgentEnabled ? .openclaw : nil,
             cursorAgentEnabled ? .cursor : nil,
             piAgentEnabled ? .pi : nil,
-            kimiAgentEnabled ? .kimi : nil
+            kimiAgentEnabled ? .kimi : nil,
+            grokAgentEnabled ? .grok : nil
         ].compactMap { $0 }
         for source in sources {
             requestProviderRefresh(source: source, reason: "unified-refresh", trigger: trigger)
@@ -2152,6 +2214,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         case .cursor: return cursor.allSessions
         case .pi: return pi.allSessions
         case .kimi: return kimi.allSessions
+        case .grok: return grok.allSessions
         }
     }
 
@@ -2198,6 +2261,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         case .cursor: return cursorAgentEnabled && !cursor.isIndexing
         case .pi: return piAgentEnabled && !pi.isIndexing
         case .kimi: return kimiAgentEnabled && !kimi.isIndexing
+        case .grok: return grokAgentEnabled && !grok.isIndexing
         }
     }
 
@@ -2315,6 +2379,8 @@ final class UnifiedSessionIndexer: ObservableObject {
             livePath = pi.allSessions.first(where: { $0.id == context.sessionID })?.filePath
         case .kimi:
             livePath = kimi.allSessions.first(where: { $0.id == context.sessionID })?.filePath
+        case .grok:
+            livePath = grok.allSessions.first(where: { $0.id == context.sessionID })?.filePath
         }
         if let livePath, !livePath.isEmpty { return livePath }
         return context.filePath
@@ -2417,6 +2483,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         case .cursor: cursor.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
         case .pi: pi.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
         case .kimi: kimi.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
+        case .grok: grok.refresh(mode: mode, trigger: trigger, executionProfile: executionProfile)
         }
     }
 
@@ -2434,6 +2501,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         case .cursor: return cursor.isIndexing
         case .pi: return pi.isIndexing
         case .kimi: return kimi.isIndexing
+        case .grok: return grok.isIndexing
         }
     }
 
@@ -2649,6 +2717,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         phases[.cursor] = (cursorAgentEnabled && includeCursor) ? cursor.launchPhase : .ready
         phases[.pi] = (piAgentEnabled && includePi) ? pi.launchPhase : .ready
         phases[.kimi] = (kimiAgentEnabled && includeKimi) ? kimi.launchPhase : .ready
+        phases[.grok] = (grokAgentEnabled && includeGrok) ? grok.launchPhase : .ready
 
         let overall: LaunchPhase
         if phases.values.contains(.error) {
@@ -2697,6 +2766,7 @@ final class UnifiedSessionIndexer: ObservableObject {
         if work.enablement.cursor { merged.append(contentsOf: work.cursorList) }
         if work.enablement.pi { merged.append(contentsOf: work.piList) }
         if work.enablement.kimi { merged.append(contentsOf: work.kimiList) }
+        if work.enablement.grok { merged.append(contentsOf: work.grokList) }
         for index in merged.indices {
             merged[index].isFavorite = work.favoritesSnapshot.contains(id: merged[index].id, source: merged[index].source)
         }
@@ -2723,7 +2793,7 @@ final class UnifiedSessionIndexer: ObservableObject {
     /// because their lightweight pass does not populate `lightweightCommands`.
     static func passesHasCommandsFilter(_ session: Session) -> Bool {
         switch session.source {
-        case .codex, .opencode, .hermes, .copilot, .droid, .openclaw, .cursor, .pi, .kimi:
+        case .codex, .opencode, .hermes, .copilot, .droid, .openclaw, .cursor, .pi, .kimi, .grok:
             // hasToolCallEvent is precomputed once at Session construction from
             // `events` (Session.swift), so this no longer rescans the full
             // events array per session per recompute.
@@ -2767,6 +2837,7 @@ final class UnifiedSessionIndexer: ObservableObject {
             case .cursor:   return cursorAgentEnabled && includeCursor
             case .pi:       return piAgentEnabled && includePi
             case .kimi:     return kimiAgentEnabled && includeKimi
+            case .grok:     return grokAgentEnabled && includeGrok
             }
         }
 

--- a/AgentSessions/Views/Preferences/PreferencesConstants.swift
+++ b/AgentSessions/Views/Preferences/PreferencesConstants.swift
@@ -88,6 +88,7 @@ enum PreferencesKey {
     static let cursorCLIAvailable = "CursorCLIAvailable"
     static let piCLIAvailable = "PiCLIAvailable"
     static let kimiCLIAvailable = "KimiCLIAvailable"
+    static let grokCLIAvailable = "GrokCLIAvailable"
 
     enum Agents {
         static let didSeedEnabledAgents = "DidSeedEnabledAgents_v1"
@@ -102,6 +103,7 @@ enum PreferencesKey {
         static let cursorEnabled = "AgentEnabledCursor"
         static let piEnabled = "AgentEnabledPi"
         static let kimiEnabled = "AgentEnabledKimi"
+        static let grokEnabled = "AgentEnabledGrok"
         static let knownAvailableProviders = "KnownAvailableProviders"
     }
 
@@ -160,6 +162,7 @@ enum PreferencesKey {
         static let cursorSessionsRootOverride = "CursorSessionsRootOverride"
         static let piSessionsRootOverride = "PiSessionsRootOverride"
         static let kimiSessionsRootOverride = "KimiSessionsRootOverride"
+        static let grokSessionsRootOverride = "GrokSessionsRootOverride"
     }
 
     enum Archives {

--- a/AgentSessions/Views/Preferences/PreferencesView+Grok.swift
+++ b/AgentSessions/Views/Preferences/PreferencesView+Grok.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+import AppKit
+
+extension PreferencesView {
+    var grokTab: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Grok").font(.title2).fontWeight(.semibold)
+
+            if !grokAgentEnabled {
+                PreferenceCallout {
+                    Text("This agent is disabled in General -> Active CLI agents.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Group {
+                sectionHeader("Grok CLI Binary")
+                VStack(alignment: .leading, spacing: 10) {
+                    labeledRow("Binary Source") {
+                        Picker("", selection: Binding(
+                            get: { grokSettings.binaryPath.isEmpty ? 0 : 1 },
+                            set: { idx in
+                                if idx == 0 {
+                                    grokSettings.setBinaryPath("")
+                                    scheduleGrokProbe()
+                                } else {
+                                    pickGrokBinary()
+                                }
+                            }
+                        )) {
+                            Text("Auto").tag(0)
+                            Text("Custom").tag(1)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(maxWidth: 220)
+                        .help("Use the auto-detected Grok CLI or supply a custom path")
+                    }
+
+                    if grokSettings.binaryPath.isEmpty {
+                        HStack {
+                            Text("Detected:").font(.caption)
+                            Text(grokVersionString ?? "unknown").font(.caption).monospaced()
+                        }
+                        if let path = grokResolvedPath {
+                            Text(path).font(.caption2).foregroundStyle(.secondary).lineLimit(1).truncationMode(.middle)
+                        }
+
+                        if grokProbeState == .failure && grokVersionString == nil {
+                            PreferenceCallout {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Grok CLI not found")
+                                        .font(.caption)
+                                        .fontWeight(.medium)
+                                    Text("Install it from code.grok.com and ensure `grok` is on PATH.")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+
+                        HStack(spacing: 12) {
+                            Button("Check Version") { probeGrok() }
+                                .buttonStyle(.bordered)
+                                .help("Query the detected Grok CLI for its version")
+                            Button("Copy Path") {
+                                if let p = grokResolvedPath {
+                                    NSPasteboard.general.clearContents()
+                                    NSPasteboard.general.setString(p, forType: .string)
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .help("Copy the detected Grok CLI path to clipboard")
+                            .disabled(grokResolvedPath == nil)
+                            Button("Reveal") {
+                                if let p = grokResolvedPath {
+                                    NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: p)])
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .help("Reveal the detected Grok CLI binary in Finder")
+                            .disabled(grokResolvedPath == nil)
+                        }
+                    } else {
+                        HStack(spacing: 10) {
+                            TextField("/path/to/grok", text: Binding(get: { grokSettings.binaryPath }, set: { grokSettings.setBinaryPath($0) }))
+                                .textFieldStyle(.roundedBorder)
+                                .frame(maxWidth: 360)
+                                .onSubmit { scheduleGrokProbe() }
+                                .onChange(of: grokSettings.binaryPath) { _, _ in scheduleGrokProbe() }
+                                .help("Enter the full path to a custom Grok CLI binary")
+                            Button("Choose...", action: pickGrokBinary)
+                                .buttonStyle(.borderedProminent)
+                                .help("Select the Grok CLI binary from the filesystem")
+                        }
+                        if !grokSettings.binaryPath.isEmpty, grokProbeState == .failure {
+                            Text("Invalid Grok binary path.")
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
+
+                    Text("Used for both the copied resume command and Resume in Terminal. Grok resumes by session id (`--resume`), falling back to `--continue` for the working directory.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                sectionHeader("Sessions Storage")
+                VStack(alignment: .leading, spacing: 10) {
+                    labeledRow("Status") {
+                        let status = AgentEnablement.availabilityStatus(for: .grok)
+                        HStack(spacing: 4) {
+                            Image(systemName: status.isAvailable ? "checkmark.circle.fill" : "xmark.circle")
+                                .foregroundColor(status.isAvailable ? .green : .secondary)
+                            Text(status.statusText)
+                                .font(.caption)
+                        }
+                    }
+
+                    labeledRow("Default Root") {
+                        Text("~/.grok/sessions")
+                            .font(.caption)
+                            .monospaced()
+                            .foregroundStyle(.secondary)
+                    }
+
+                    labeledRow("Storage Root") {
+                        HStack(spacing: 10) {
+                            TextField("Custom root (leave empty for default)", text: $grokSessionsPath)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.caption)
+                                .onSubmit {
+                                    validateGrokSessionsPath()
+                                    commitGrokSessionsPathIfValid()
+                                }
+                                .onChange(of: grokSessionsPath) { _, _ in
+                                    scheduleGrokSessionsPathValidation()
+                                }
+                            Button("Choose...", action: pickGrokSessionsFolder)
+                                .buttonStyle(.borderedProminent)
+                                .help("Select a Grok sessions directory")
+                        }
+                    }
+
+                    if !grokSessionsPathValid {
+                        Text("Choose an existing directory.")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+
+                    Text("Grok writes one wire.jsonl journal per agent under its sessions directory. Override only when you point GROK_CODE_HOME at a non-default location.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+        }
+        .onAppear {
+            scheduleGrokProbe()
+        }
+    }
+
+    func pickGrokBinary() {
+        let panel = NSOpenPanel()
+        panel.title = "Select Grok CLI Binary"
+        panel.message = "Choose the grok executable file"
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.treatsFilePackagesAsDirectories = false
+        panel.directoryURL = URL(fileURLWithPath: "/opt/homebrew/bin", isDirectory: true)
+
+        if panel.runModal() == .OK, let url = panel.url {
+            grokSettings.setBinaryPath(url.path)
+            scheduleGrokProbe()
+        }
+    }
+
+    func validateGrokSessionsPath() {
+        guard !grokSessionsPath.isEmpty else {
+            grokSessionsPathValid = true
+            return
+        }
+        let expanded = (grokSessionsPath as NSString).expandingTildeInPath
+        var isDir: ObjCBool = false
+        grokSessionsPathValid = FileManager.default.fileExists(atPath: expanded, isDirectory: &isDir) && isDir.boolValue
+    }
+
+    func commitGrokSessionsPathIfValid() {
+        guard grokSessionsPathValid else { return }
+        UserDefaults.standard.set(grokSessionsPath, forKey: PreferencesKey.Paths.grokSessionsRootOverride)
+    }
+
+    func scheduleGrokSessionsPathValidation() {
+        grokSessionsPathDebounce?.cancel()
+        let work = DispatchWorkItem {
+            validateGrokSessionsPath()
+            commitGrokSessionsPathIfValid()
+        }
+        grokSessionsPathDebounce = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
+    }
+
+    func pickGrokSessionsFolder() {
+        let panel = NSOpenPanel()
+        panel.title = "Select Grok Sessions Directory"
+        panel.message = "Choose the Grok sessions folder"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        if !grokSessionsPath.isEmpty {
+            panel.directoryURL = URL(fileURLWithPath: (grokSessionsPath as NSString).expandingTildeInPath)
+        } else {
+            panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".grok/sessions")
+        }
+
+        if panel.runModal() == .OK, let url = panel.url {
+            grokSessionsPath = url.path
+            validateGrokSessionsPath()
+            commitGrokSessionsPathIfValid()
+        }
+    }
+}

--- a/AgentSessions/Views/PreferencesView.swift
+++ b/AgentSessions/Views/PreferencesView.swift
@@ -19,6 +19,7 @@ struct PreferencesView: View {
     @ObservedObject var cursorSettings = CursorSettings.shared
     @ObservedObject var piSettings = PiSettings.shared
     @ObservedObject var kimiSettings = KimiSettings.shared
+    @ObservedObject var grokSettings = GrokSettings.shared
     @State var showingResetConfirm: Bool = false
     @AppStorage(PreferencesKey.showUsageStrip) var showUsageStrip: Bool = false
     // Codex tracking master toggle
@@ -65,6 +66,7 @@ struct PreferencesView: View {
     @AppStorage(PreferencesKey.cursorCLIAvailable) var cursorCLIAvailable: Bool = true
     @AppStorage(PreferencesKey.piCLIAvailable) var piCLIAvailable: Bool = true
     @AppStorage(PreferencesKey.kimiCLIAvailable) var kimiCLIAvailable: Bool = true
+    @AppStorage(PreferencesKey.grokCLIAvailable) var grokCLIAvailable: Bool = true
     // Global agent enablement
     @AppStorage(PreferencesKey.Agents.codexEnabled) var codexAgentEnabled: Bool = true
     @AppStorage(PreferencesKey.Agents.claudeEnabled) var claudeAgentEnabled: Bool = true
@@ -77,6 +79,7 @@ struct PreferencesView: View {
     @AppStorage(PreferencesKey.Agents.cursorEnabled) var cursorAgentEnabled: Bool = true
     @AppStorage(PreferencesKey.Agents.piEnabled) var piAgentEnabled: Bool = AgentEnablement.isEnabled(.pi)
     @AppStorage(PreferencesKey.Agents.kimiEnabled) var kimiAgentEnabled: Bool = AgentEnablement.isEnabled(.kimi)
+    @AppStorage(PreferencesKey.Agents.grokEnabled) var grokAgentEnabled: Bool = AgentEnablement.isEnabled(.grok)
     // Menu bar prefs
     @AppStorage(PreferencesKey.menuBarEnabled) var menuBarEnabled: Bool = false
     @AppStorage(PreferencesKey.menuBarScope) var menuBarScopeRaw: String = MenuBarScope.both.rawValue
@@ -235,6 +238,10 @@ struct PreferencesView: View {
     @State var kimiVersionString: String? = nil
     @State var kimiResolvedPath: String? = nil
     @State var kimiProbeDebounce: DispatchWorkItem? = nil
+    @State var grokProbeState: ProbeState = .idle
+    @State var grokVersionString: String? = nil
+    @State var grokResolvedPath: String? = nil
+    @State var grokProbeDebounce: DispatchWorkItem? = nil
     // Copilot sessions directory override
     @AppStorage(PreferencesKey.Paths.copilotSessionsRootOverride) var copilotSessionsPath: String = ""
     @State var copilotSessionsPathValid: Bool = true
@@ -272,6 +279,11 @@ struct PreferencesView: View {
     @AppStorage(PreferencesKey.Paths.kimiSessionsRootOverride) var kimiSessionsPath: String = ""
     @State var kimiSessionsPathValid: Bool = true
     @State var kimiSessionsPathDebounce: DispatchWorkItem? = nil
+
+    // Grok CLI sessions root
+    @AppStorage(PreferencesKey.Paths.grokSessionsRootOverride) var grokSessionsPath: String = ""
+    @State var grokSessionsPathValid: Bool = true
+    @State var grokSessionsPathDebounce: DispatchWorkItem? = nil
     // Per-agent update flow state
     @State var agentUpdateCheckingSources: Set<SessionSource> = []
     @State var agentUpdatingSources: Set<SessionSource> = []
@@ -279,7 +291,7 @@ struct PreferencesView: View {
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {
             List(selection: $selectedTab) {
-                ForEach(visibleTabs.filter { $0 != .about && $0 != .codexCLI && $0 != .claudeResume && $0 != .opencode && $0 != .antigravityCLI && $0 != .hermesCLI && $0 != .copilotCLI && $0 != .droidCLI && $0 != .openClawCLI && $0 != .cursor && $0 != .pi && $0 != .kimi }, id: \.self) { tab in
+                ForEach(visibleTabs.filter { $0 != .about && $0 != .codexCLI && $0 != .claudeResume && $0 != .opencode && $0 != .antigravityCLI && $0 != .hermesCLI && $0 != .copilotCLI && $0 != .droidCLI && $0 != .openClawCLI && $0 != .cursor && $0 != .pi && $0 != .kimi && $0 != .grok }, id: \.self) { tab in
                     Label(tab.title, systemImage: tab.iconName)
                         .tag(tab)
                 }
@@ -291,7 +303,7 @@ struct PreferencesView: View {
                     Label(tab.title, systemImage: tab.iconName)
                         .tag(tab)
                 }
-                ForEach([PreferencesTab.cursor, .pi, .kimi, .hermesCLI, .openClawCLI], id: \.self) { tab in
+                ForEach([PreferencesTab.cursor, .pi, .kimi, .grok, .hermesCLI, .openClawCLI], id: \.self) { tab in
                     Label(tab.title, systemImage: tab.iconName)
                         .tag(tab)
                 }
@@ -418,6 +430,8 @@ struct PreferencesView: View {
                 piTab
             case .kimi:
                 kimiTab
+            case .grok:
+                grokTab
             case .about:
                 aboutTab
             }
@@ -735,6 +749,8 @@ struct PreferencesView: View {
         piSettings.setResolvedBinaryPath(nil)
         kimiSettings.setBinaryPath("")
         kimiSettings.setResolvedBinaryPath(nil)
+        grokSettings.setBinaryPath("")
+        grokSettings.setResolvedBinaryPath(nil)
         droidSettings.setBinaryPath("")
         openClawBinaryPath = ""
         validateOpenClawBinaryPath()
@@ -746,11 +762,13 @@ struct PreferencesView: View {
         openClawSessionsPath = ""
         piSessionsPath = ""
         kimiSessionsPath = ""
+        grokSessionsPath = ""
         validateDroidSessionsPath()
         validateDroidProjectsPath()
         validateOpenClawSessionsPath()
         validatePiSessionsPath()
         validateKimiSessionsPath()
+        validateGrokSessionsPath()
 
         cockpitReduceTransparency = true
         usageLimitCockpitProjectionEnabled = true
@@ -894,6 +912,7 @@ struct PreferencesView: View {
         case .cursor: scheduleCursorProbe()
         case .pi: schedulePiProbe()
         case .kimi: scheduleKimiProbe()
+        case .grok: scheduleGrokProbe()
         }
     }
 
@@ -921,6 +940,8 @@ struct PreferencesView: View {
             return piResolvedPath
         case .kimi:
             return kimiResolvedPath
+        case .grok:
+            return grokResolvedPath
         }
     }
 
@@ -958,6 +979,9 @@ struct PreferencesView: View {
             return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : value
         case .kimi:
             let value = kimiSettings.binaryPath
+            return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : value
+        case .grok:
+            let value = grokSettings.binaryPath
             return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : value
         }
     }
@@ -1094,6 +1118,7 @@ enum PreferencesTab: String, CaseIterable, Identifiable {
     case cursor
     case pi
     case kimi
+    case grok
     case about
 
     var id: String { rawValue }
@@ -1119,6 +1144,7 @@ enum PreferencesTab: String, CaseIterable, Identifiable {
         case .cursor: return "Cursor"
         case .pi: return "Pi"
         case .kimi: return "Kimi Code"
+        case .grok: return "Grok CLI"
         case .about: return "About"
         }
     }
@@ -1144,6 +1170,7 @@ enum PreferencesTab: String, CaseIterable, Identifiable {
         case .cursor: return "cursorarrow.rays"
         case .pi: return "p.circle"
         case .kimi: return "k.circle"
+        case .grok: return "g.circle"
         case .about: return "info.circle"
         }
     }
@@ -1151,7 +1178,7 @@ enum PreferencesTab: String, CaseIterable, Identifiable {
 
 private extension PreferencesView {
     // Sidebar order: General → Quota Meter → Unified Window → Usage Tracking → Limit Alerts → Usage Probes → Menu Bar → Advanced → About → Agents
-    var visibleTabs: [PreferencesTab] { [.general, .agentCockpit, .unified, .usageTracking, .limitAlerts, .usageProbes, .menuBar, .advanced, .about, .codexCLI, .claudeResume, .opencode, .antigravityCLI, .copilotCLI, .cursor, .pi, .kimi, .hermesCLI, .openClawCLI] }
+    var visibleTabs: [PreferencesTab] { [.general, .agentCockpit, .unified, .usageTracking, .limitAlerts, .usageProbes, .menuBar, .advanced, .about, .codexCLI, .claudeResume, .opencode, .antigravityCLI, .copilotCLI, .cursor, .pi, .kimi, .grok, .hermesCLI, .openClawCLI] }
 }
 
 // MARK: - Probe helpers
@@ -1367,6 +1394,40 @@ extension PreferencesView {
         }
     }
 
+    func probeGrok() {
+        if grokProbeState == .probing { return }
+        grokProbeState = .probing
+        grokVersionString = nil
+        grokResolvedPath = nil
+        let override = grokSettings.binaryPath.isEmpty ? nil : grokSettings.binaryPath
+        let isAutoProbe = override == nil
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = GrokCLIEnvironment().probe(customPath: override)
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let res):
+                    self.grokVersionString = res.versionString
+                    self.grokResolvedPath = res.binaryURL.path
+                    if isAutoProbe {
+                        self.grokSettings.setResolvedBinary(res.binaryURL.path,
+                                                            supportsResume: res.supportsResume,
+                                                            supportsContinue: res.supportsContinue)
+                    }
+                    self.grokProbeState = .success
+                    self.grokCLIAvailable = true
+                case .failure:
+                    self.grokVersionString = nil
+                    self.grokResolvedPath = nil
+                    if isAutoProbe {
+                        self.grokSettings.setResolvedBinaryPath(nil)
+                    }
+                    self.grokProbeState = .failure
+                    self.grokCLIAvailable = false
+                }
+            }
+        }
+    }
+
     func probeOpenClaw() {
         if openClawProbeState == .probing { return }
         openClawProbeState = .probing
@@ -1415,6 +1476,8 @@ extension PreferencesView {
             if piVersionString == nil && piProbeState != .probing { probePi() }
         case .kimi:
             if kimiVersionString == nil && kimiProbeState != .probing { probeKimi() }
+        case .grok:
+            if grokVersionString == nil && grokProbeState != .probing { probeGrok() }
         case .menuBar, .limitAlerts, .usageProbes, .general, .unified, .advanced, .agentCockpit, .about:
             break
         }
@@ -1473,6 +1536,13 @@ extension PreferencesView {
         kimiProbeDebounce?.cancel()
         let work = DispatchWorkItem { probeKimi() }
         kimiProbeDebounce = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: work)
+    }
+
+    func scheduleGrokProbe() {
+        grokProbeDebounce?.cancel()
+        let work = DispatchWorkItem { probeGrok() }
+        grokProbeDebounce = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: work)
     }
 

--- a/AgentSessions/Views/SessionTerminalView.swift
+++ b/AgentSessions/Views/SessionTerminalView.swift
@@ -307,6 +307,7 @@ struct SessionTerminalView: View {
         case .cursor: return "Cursor"
         case .pi: return "Pi"
         case .kimi: return "Kimi Code"
+        case .grok: return "Grok CLI"
         }
     }
 

--- a/AgentSessions/Views/UnifiedSessionsView.swift
+++ b/AgentSessions/Views/UnifiedSessionsView.swift
@@ -340,6 +340,7 @@ struct UnifiedSessionsView: View {
     let cursorIndexer: CursorSessionIndexer
     let piIndexer: PiSessionIndexer
     let kimiIndexer: KimiSessionIndexer
+    let grokIndexer: GrokSessionIndexer
     @EnvironmentObject var codexUsageModel: CodexUsageModel
     @EnvironmentObject var claudeUsageModel: ClaudeUsageModel
     @Environment(CodexActiveSessionsModel.self) var activeCodexSessions
@@ -427,6 +428,7 @@ struct UnifiedSessionsView: View {
 	    @AppStorage(PreferencesKey.Agents.cursorEnabled) private var cursorAgentEnabled: Bool = true
 	    @AppStorage(PreferencesKey.Agents.piEnabled) private var piAgentEnabled: Bool = AgentEnablement.isEnabled(.pi)
 	    @AppStorage(PreferencesKey.Agents.kimiEnabled) private var kimiAgentEnabled: Bool = AgentEnablement.isEnabled(.kimi)
+	    @AppStorage(PreferencesKey.Agents.grokEnabled) private var grokAgentEnabled: Bool = AgentEnablement.isEnabled(.grok)
 	    @State private var autoSelectEnabled: Bool = true
 	    @State private var isDatasetChurning: Bool = false
 	    // Set by updateCachedRows() exactly when the canonical selection id was
@@ -487,6 +489,7 @@ struct UnifiedSessionsView: View {
          cursorIndexer: CursorSessionIndexer,
          piIndexer: PiSessionIndexer,
          kimiIndexer: KimiSessionIndexer,
+         grokIndexer: GrokSessionIndexer,
          analyticsReady: Bool,
          analyticsPhase: AnalyticsIndexPhase,
          analyticsIsStale: Bool,
@@ -504,6 +507,7 @@ struct UnifiedSessionsView: View {
         self.cursorIndexer = cursorIndexer
         self.piIndexer = piIndexer
         self.kimiIndexer = kimiIndexer
+        self.grokIndexer = grokIndexer
         self.analyticsReady = analyticsReady
         self.analyticsPhase = analyticsPhase
         self.analyticsIsStale = analyticsIsStale
@@ -575,6 +579,11 @@ struct UnifiedSessionsView: View {
                 transcriptCache: kimiIndexer.searchTranscriptCache,
                 update: { kimiIndexer.updateSession($0) },
                 parseFull: { url, _ in KimiSessionParser.parseFileFull(at: url, allowLargeFile: true) }
+            ),
+            .grok: .init(
+                transcriptCache: grokIndexer.searchTranscriptCache,
+                update: { grokIndexer.updateSession($0) },
+                parseFull: { url, _ in GrokSessionParser.parseFileFull(at: url, allowLargeFile: true) }
             ),
         ])
         _searchCoordinator = StateObject(wrappedValue: SearchCoordinator(store: store))
@@ -680,8 +689,10 @@ struct UnifiedSessionsView: View {
 
         let afterKimi = afterPi
             .onChange(of: unified.includeKimi) { _, _ in restartSearchIfRunning() }
+        let afterGrok = afterKimi
+            .onChange(of: unified.includeGrok) { _, _ in restartSearchIfRunning() }
 
-        let afterActiveOnly = afterKimi
+        let afterActiveOnly = afterGrok
             .onChange(of: showActiveSessionsOnly) { _, _ in
                 if !liveSessionsFeatureEnabled {
                     showActiveSessionsOnly = false
@@ -734,6 +745,7 @@ struct UnifiedSessionsView: View {
 			.onChange(of: openCodeAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
 			.onChange(of: copilotAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
 			.onChange(of: kimiAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
+			.onChange(of: grokAgentEnabled) { _, _ in flashAgentEnablementNoticeIfNeeded() }
 
 		let afterSessions = afterAgents
 			.onReceive(unified.$sessions) { sessions in
@@ -1535,6 +1547,11 @@ struct UnifiedSessionsView: View {
             // valid fallback when the working directory is known, so
             // copyResumeCommand may still decline; see its .kimi arm.
             return true
+        case .grok:
+            // session.id is the on-disk session dir (a bare UUIDv7).
+            // `--continue` is only a valid fallback when the working directory
+            // is known, so copyResumeCommand may still decline; see its .grok arm.
+            return true
         case .antigravity:
             return (antigravityCLISessionID ?? AntigravitySessionIDHelper.deriveSessionID(from: session)) != nil
         default:
@@ -1657,6 +1674,20 @@ struct UnifiedSessionsView: View {
             let command = wd.map { "cd \(builder.shellQuoteIfNeeded($0.path)) && \(core)" } ?? core
             write(command)
 
+        case .grok:
+            let settings = GrokSettings.shared
+            let wd = effectiveWorkingDirectoryURL(for: session)
+            guard let plan = settings.copyCommandPlan(sessionID: session.id) else { return }
+            // Same refusal as GrokResumeCoordinator: `--continue` resolves
+            // against the working directory, so without a `cd` it would hand the
+            // user a command that reopens an unrelated session.
+            if case .continueMostRecent = plan.strategy, wd == nil { return }
+            let builder = GrokResumeCommandBuilder()
+            guard let core = try? builder.makeCoreCommand(strategy: plan.strategy,
+                                                          binaryCommand: plan.binary) else { return }
+            let command = wd.map { "cd \(builder.shellQuoteIfNeeded($0.path)) && \(core)" } ?? core
+            write(command)
+
         case .antigravity:
             let settings = AntigravityCLISettings.shared
             guard let sid = antigravityCLISessionID ?? AntigravitySessionIDHelper.deriveSessionID(from: session) else { return }
@@ -1687,7 +1718,8 @@ struct UnifiedSessionsView: View {
                                openclawIndexer: openclawIndexer,
                                cursorIndexer: cursorIndexer,
                                piIndexer: piIndexer,
-                               kimiIndexer: kimiIndexer)
+                               kimiIndexer: kimiIndexer,
+                               grokIndexer: grokIndexer)
                 .environmentObject(focusCoordinator)
                 .environmentObject(searchState)
                 .id("transcript-host")
@@ -1710,6 +1742,7 @@ struct UnifiedSessionsView: View {
                         case .cursor: return "Cursor"
                         case .pi: return "Pi"
                         case .kimi: return "Kimi Code"
+                        case .grok: return "Grok CLI"
                         }
                     }()
                     let accent: Color = sourceAccent(s)
@@ -1983,6 +2016,11 @@ struct UnifiedSessionsView: View {
             // ⌘1–⌘9 are fully allocated (Codex=1, Claude=2, … Pi=9), so Kimi
             // takes no shortcut — same as Hermes.
             specs.append(.init(id: "kimi", title: "Kimi Code", color: Color.agentKimi, isOn: $unified.includeKimi, shortcut: nil))
+        }
+        if grokAgentEnabled {
+            // ⌘1–⌘9 are fully allocated (Codex=1, Claude=2, … Pi=9), so Kimi
+            // takes no shortcut — same as Hermes.
+            specs.append(.init(id: "grok", title: "Grok CLI", color: Color.agentGrok, isOn: $unified.includeGrok, shortcut: nil))
         }
         return specs
     }
@@ -2495,6 +2533,8 @@ struct UnifiedSessionsView: View {
             if !unified.includePi { unified.includePi = true }
         case .kimi:
             if !unified.includeKimi { unified.includeKimi = true }
+        case .grok:
+            if !unified.includeGrok { unified.includeGrok = true }
         }
     }
 
@@ -2553,6 +2593,8 @@ struct UnifiedSessionsView: View {
             if unified.piAgentEnabled, let e = piIndexer.allSessions.first(where: { $0.id == id }), e.events.isEmpty { piIndexer.reloadSession(id: id); return true }
         case .kimi:
             if unified.kimiAgentEnabled, let e = kimiIndexer.allSessions.first(where: { $0.id == id }), e.events.isEmpty { kimiIndexer.reloadSession(id: id); return true }
+        case .grok:
+            if unified.grokAgentEnabled, let e = grokIndexer.allSessions.first(where: { $0.id == id }), e.events.isEmpty { grokIndexer.reloadSession(id: id); return true }
         }
         return false
     }
@@ -2916,6 +2958,7 @@ struct UnifiedSessionsView: View {
         case .cursor: label = "Cursor"
         case .pi: label = "Pi"
         case .kimi: label = "Kimi Code"
+        case .grok: label = "Grok CLI"
         }
         let isSubagentRow = (hierarchyRowMeta[session.id]?.depth ?? 0) > 0
         return HStack(spacing: 6) {
@@ -3189,6 +3232,7 @@ struct UnifiedSessionsView: View {
         case .cursor: return "Cursor CLI"
         case .pi: return "Pi CLI"
         case .kimi: return "Kimi Code"
+        case .grok: return "Grok CLI"
         case .antigravity: return "Antigravity CLI"
         default: return "CLI"
         }
@@ -3200,7 +3244,7 @@ struct UnifiedSessionsView: View {
             return canResumeCodexInCLI(s)
         case .claude:
             return !s.isClaudeWorkflowSubagent
-        case .opencode, .hermes, .copilot, .cursor, .pi, .kimi:
+        case .opencode, .hermes, .copilot, .cursor, .pi, .kimi, .grok:
             return true
         case .antigravity:
             return (antigravityCLISessionID ?? AntigravitySessionIDHelper.deriveSessionID(from: s)) != nil
@@ -3346,6 +3390,25 @@ struct UnifiedSessionsView: View {
                 let result = await coord.resumeInTerminal(input: input, dryRun: false)
                 reportResumeFailure(launched: result.launched, error: result.error, source: s.source, in: presentingWindow)
             }
+        case .grok:
+            let settings = GrokSettings.shared
+            let sid = s.id
+            let wd = effectiveWorkingDirectoryURL(for: s)
+            let bin = settings.binaryPath.isEmpty ? nil : settings.binaryPath
+            let input = GrokResumeInput(sessionID: sid, workingDirectory: wd, binaryOverride: bin)
+            Task { @MainActor in
+                let launcher: GrokTerminalLaunching = {
+                    switch ResumePreferenceHelpers.resolveTerminalKind() {
+                    case .iterm2:                  return GrokITermLauncher()
+                    case .warp:                    return GrokWarpLauncher()
+                    case .warpPreview:             return GrokWarpPreviewLauncher()
+                    case .terminalApp, .unknown:   return GrokTerminalLauncher()
+                    }
+                }()
+                let coord = GrokResumeCoordinator(env: GrokCLIEnvironment(), builder: GrokResumeCommandBuilder(), launcher: launcher)
+                let result = await coord.resumeInTerminal(input: input, dryRun: false)
+                reportResumeFailure(launched: result.launched, error: result.error, source: s.source, in: presentingWindow)
+            }
         case .antigravity:
             let settings = AntigravityCLISettings.shared
             let sid = AntigravitySessionIDHelper.deriveSessionID(from: s)
@@ -3459,12 +3522,13 @@ struct UnifiedSessionsView: View {
                                 includeCursor: unified.includeCursor && cursorAgentEnabled,
                                 includePi: unified.includePi && piAgentEnabled,
                                 includeKimi: unified.includeKimi && kimiAgentEnabled,
+                                includeGrok: unified.includeGrok && grokAgentEnabled,
                                 enableDeepScan: searchCoordinator.deepScanEnabled,
                                 all: unified.allSessions)
     }
 
     private func flashAgentEnablementNoticeIfNeeded() {
-        let anyDisabled = !(codexAgentEnabled && claudeAgentEnabled && antigravityAgentEnabled && openCodeAgentEnabled && hermesAgentEnabled && copilotAgentEnabled && droidAgentEnabled && openClawAgentEnabled && cursorAgentEnabled && piAgentEnabled && kimiAgentEnabled)
+        let anyDisabled = !(codexAgentEnabled && claudeAgentEnabled && antigravityAgentEnabled && openCodeAgentEnabled && hermesAgentEnabled && copilotAgentEnabled && droidAgentEnabled && openClawAgentEnabled && cursorAgentEnabled && piAgentEnabled && kimiAgentEnabled && grokAgentEnabled)
         guard anyDisabled else {
             withAnimation { showAgentEnablementNotice = false }
             return
@@ -3489,6 +3553,7 @@ struct UnifiedSessionsView: View {
         case .cursor: return Color.agentCursor
         case .pi: return Color.agentPi
         case .kimi: return Color.agentKimi
+        case .grok: return Color.agentGrok
         }
     }
 
@@ -3983,6 +4048,7 @@ private struct TranscriptHostView: View {
     let cursorIndexer: CursorSessionIndexer
     let piIndexer: PiSessionIndexer
     let kimiIndexer: KimiSessionIndexer
+    let grokIndexer: GrokSessionIndexer
 
     var body: some View {
         ZStack { // keep one stable container to avoid split reset
@@ -4199,6 +4265,7 @@ private struct UnifiedSearchFiltersView: View {
     @ObservedObject var searchState: UnifiedSearchState
     @AppStorage(PreferencesKey.Agents.piEnabled) private var piAgentEnabled: Bool = AgentEnablement.isEnabled(.pi)
     @AppStorage(PreferencesKey.Agents.kimiEnabled) private var kimiAgentEnabled: Bool = AgentEnablement.isEnabled(.kimi)
+    @AppStorage(PreferencesKey.Agents.grokEnabled) private var grokAgentEnabled: Bool = AgentEnablement.isEnabled(.grok)
     @FocusState private var searchFocus: SearchFocusTarget?
     @State private var searchDebouncer: DispatchWorkItem? = nil
     @State private var focusRequestToken: Int = 0
@@ -4336,6 +4403,7 @@ private struct UnifiedSearchFiltersView: View {
                      includeCursor: unified.includeCursor,
                      includePi: unified.includePi && piAgentEnabled,
                      includeKimi: unified.includeKimi && kimiAgentEnabled,
+                     includeGrok: unified.includeGrok && grokAgentEnabled,
                      enableDeepScan: deepScan,
                      all: unified.allSessions)
     }
@@ -4373,6 +4441,7 @@ private struct UnifiedSearchFiltersView: View {
                          includeCursor: unified.includeCursor,
                          includePi: unified.includePi && piAgentEnabled,
                          includeKimi: unified.includeKimi && kimiAgentEnabled,
+                         includeGrok: unified.includeGrok && grokAgentEnabled,
                          enableDeepScan: false,
                          all: unified.allSessions)
         }

--- a/AgentSessionsTests/CodexActiveSessionsRegistryTests.swift
+++ b/AgentSessionsTests/CodexActiveSessionsRegistryTests.swift
@@ -3777,6 +3777,7 @@ final class CodexActiveSessionsRegistryTests: XCTestCase {
             cursorList: [],
             piList: [],
             kimiList: [],
+            grokList: [],
             favoritesSnapshot: UnifiedSessionIndexer.FavoritesStore.Snapshot(legacyIDs: [], scopedKeys: [favoriteKey]),
             favoritesVersion: 1,
             enablement: UnifiedSessionIndexer.AgentEnablementSnapshot(
@@ -3790,7 +3791,8 @@ final class CodexActiveSessionsRegistryTests: XCTestCase {
                 openClaw: false,
                 cursor: false,
                 pi: false,
-                kimi: false
+                kimi: false,
+                grok: false
             )
         )
 
@@ -3815,6 +3817,7 @@ final class CodexActiveSessionsRegistryTests: XCTestCase {
             cursorList: [],
             piList: [],
             kimiList: [],
+            grokList: [],
             favoritesSnapshot: UnifiedSessionIndexer.FavoritesStore.Snapshot(legacyIDs: [], scopedKeys: []),
             favoritesVersion: 3,
             enablement: UnifiedSessionIndexer.AgentEnablementSnapshot(
@@ -3828,7 +3831,8 @@ final class CodexActiveSessionsRegistryTests: XCTestCase {
                 openClaw: false,
                 cursor: false,
                 pi: false,
-                kimi: false
+                kimi: false,
+                grok: false
             )
         )
 

--- a/AgentSessionsTests/GrokSessionDiscoveryTests.swift
+++ b/AgentSessionsTests/GrokSessionDiscoveryTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import AgentSessions
+
+final class GrokSessionDiscoveryTests: XCTestCase {
+    private func makeRoot() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("grok-discovery-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    @discardableResult
+    private func makeSession(in root: URL,
+                             bucket: String,
+                             id: String,
+                             withSummary: Bool = true,
+                             withTranscript: Bool = true) throws -> URL {
+        let dir = root
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(bucket, isDirectory: true)
+            .appendingPathComponent(id, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if withTranscript {
+            try #"{"type":"system","content":"x"}"#
+                .write(to: dir.appendingPathComponent("chat_history.jsonl"), atomically: true, encoding: .utf8)
+        }
+        if withSummary {
+            try #"{"info":{"id":"x"}}"#
+                .write(to: dir.appendingPathComponent("summary.json"), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    func testDiscoversTranscriptsBesideTheirSidecar() throws {
+        let root = try makeRoot()
+        try makeSession(in: root, bucket: "%2Ftmp%2Fa", id: "019f0000-0000-7000-8000-000000000001")
+        try makeSession(in: root, bucket: "%2Ftmp%2Fb", id: "019f0000-0000-7000-8000-000000000002")
+
+        let found = GrokSessionDiscovery(customRoot: root.path).discoverSessionFiles()
+        XCTAssertEqual(found.count, 2)
+        XCTAssertTrue(found.allSatisfy { $0.lastPathComponent == "chat_history.jsonl" })
+    }
+
+    /// A directory without `summary.json` is not a session: the sidecar is the
+    /// only source of identity, cwd, model and both timestamps.
+    func testSkipsSessionsMissingTheSidecar() throws {
+        let root = try makeRoot()
+        try makeSession(in: root, bucket: "%2Ftmp%2Fa", id: "019f0000-0000-7000-8000-000000000003", withSummary: false)
+
+        XCTAssertTrue(GrokSessionDiscovery(customRoot: root.path).discoverSessionFiles().isEmpty)
+    }
+
+    func testSkipsSessionsMissingTheTranscript() throws {
+        let root = try makeRoot()
+        try makeSession(in: root, bucket: "%2Ftmp%2Fa", id: "019f0000-0000-7000-8000-000000000004", withTranscript: false)
+
+        XCTAssertTrue(GrokSessionDiscovery(customRoot: root.path).discoverSessionFiles().isEmpty)
+    }
+
+    /// Session directories hold `subagents/`, `terminal/` and `compaction/`
+    /// subtrees. A recursive scan would surface a nested transcript as if it
+    /// were a top-level session, so discovery walks exactly two levels.
+    func testIgnoresNestedTranscriptsInsideSessionSubdirectories() throws {
+        let root = try makeRoot()
+        let dir = try makeSession(in: root, bucket: "%2Ftmp%2Fa", id: "019f0000-0000-7000-8000-000000000005")
+        let nested = dir.appendingPathComponent("subagents/agent-1", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try #"{"type":"system","content":"x"}"#
+            .write(to: nested.appendingPathComponent("chat_history.jsonl"), atomically: true, encoding: .utf8)
+        try #"{"info":{"id":"x"}}"#
+            .write(to: nested.appendingPathComponent("summary.json"), atomically: true, encoding: .utf8)
+
+        let found = GrokSessionDiscovery(customRoot: root.path).discoverSessionFiles()
+        XCTAssertEqual(found.count, 1)
+        XCTAssertFalse(found[0].path.contains("subagents"))
+    }
+
+    func testSessionIDIsTheDirectoryHoldingTheTranscript() {
+        let url = URL(fileURLWithPath: "/tmp/sessions/%2Ftmp%2Fa/019f0000-0000-7000-8000-000000000006/chat_history.jsonl")
+        XCTAssertEqual(GrokSessionDiscovery.sessionID(forTranscript: url),
+                       "019f0000-0000-7000-8000-000000000006")
+        XCTAssertEqual(GrokSessionDiscovery.summaryFile(forTranscript: url).lastPathComponent,
+                       "summary.json")
+    }
+
+    /// A custom root may point either at `~/.grok` or straight at its
+    /// `sessions/` child; both must resolve to the same scan root.
+    func testCustomRootAcceptsHomeOrSessionsDirectory() throws {
+        let root = try makeRoot()
+        try makeSession(in: root, bucket: "%2Ftmp%2Fa", id: "019f0000-0000-7000-8000-000000000007")
+
+        let viaHome = GrokSessionDiscovery(customRoot: root.path).discoverSessionFiles()
+        let viaSessions = GrokSessionDiscovery(
+            customRoot: root.appendingPathComponent("sessions").path).discoverSessionFiles()
+        XCTAssertEqual(viaHome.count, 1)
+        XCTAssertEqual(viaHome.map(\.path), viaSessions.map(\.path))
+    }
+}

--- a/AgentSessionsTests/GrokSessionParserTests.swift
+++ b/AgentSessionsTests/GrokSessionParserTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import AgentSessions
+
+/// The fixture reproduces the Grok CLI 1.0.0 transcript schema
+/// (`chat_format_version: 1`) as verified by `scripts/grok_chat_schema_probe.py`
+/// across 141 real sessions: every record type the parser handles is present,
+/// including a synthetic `user` turn, a `backend_tool_call`, an assistant reply
+/// with an empty `content` but live `tool_calls`, and an image content part.
+final class GrokSessionParserTests: XCTestCase {
+    private let sessionID = "019f6851-7ec4-7ef0-97d3-03f3eee38755"
+
+    /// Stages the fixture into the real on-disk layout so the parser exercises
+    /// its session-id derivation and its `summary.json` sidecar join.
+    private func stagedFixture() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("grok-fixture-\(UUID().uuidString)", isDirectory: true)
+        let sessionDir = root
+            .appendingPathComponent("sessions", isDirectory: true)
+            // Grok percent-encodes the working directory into the bucket name.
+            .appendingPathComponent("%2Ftmp%2Fas-agent-lab%2Fgrok%2Fproject", isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fixtures = repoRoot.appendingPathComponent("Resources/Fixtures/stage0/agents/grok")
+        for name in ["chat_history.jsonl", "summary.json"] {
+            try FileManager.default.copyItem(at: fixtures.appendingPathComponent(name),
+                                             to: sessionDir.appendingPathComponent(name))
+        }
+
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return sessionDir.appendingPathComponent("chat_history.jsonl")
+    }
+
+    func testParsesIdentityFromSidecar() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFileFull(at: url))
+
+        XCTAssertEqual(session.id, sessionID)
+        XCTAssertEqual(session.source, .grok)
+        XCTAssertEqual(session.model, "grok-4.5")
+        XCTAssertEqual(session.lightweightCwd, "/tmp/as-agent-lab/grok/project")
+        XCTAssertEqual(session.lightweightRepoName, "project")
+        XCTAssertEqual(session.reasoningEffort, "high")
+        XCTAssertEqual(session.surface, .cli)
+    }
+
+    /// The transcript carries no per-record time, so both bounds come from the
+    /// sidecar's RFC 3339 timestamps.
+    func testTimestampsComeFromSidecar() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFileFull(at: url))
+
+        let start = try XCTUnwrap(session.startTime)
+        let end = try XCTUnwrap(session.endTime)
+        XCTAssertEqual(start.timeIntervalSince1970, 1785492807.574131, accuracy: 0.001)
+        XCTAssertLessThan(start, end)
+    }
+
+    func testTitlePrefersGeneratedTitle() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFileFull(at: url))
+        XCTAssertEqual(session.lightweightTitle, "Read hello.py and summarize what it prints")
+    }
+
+    func testAssistantToolCallsBecomeToolCallEvents() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFileFull(at: url))
+
+        let calls = session.events.filter { $0.kind == .tool_call }
+        // Two assistant tool calls plus the server-side backend_tool_call.
+        XCTAssertEqual(calls.count, 3)
+        XCTAssertEqual(calls.first?.toolName, "read_file")
+        // `arguments` arrives as a JSON string and is passed through verbatim.
+        XCTAssertEqual(calls.first?.toolInput,
+                       "{\"target_file\":\"/tmp/as-agent-lab/grok/project/hello.py\"}")
+        XCTAssertTrue(calls.contains { $0.toolName == "web_search" })
+    }
+
+    /// An assistant record with empty `content` still has to yield its tool
+    /// calls; emitting only a meta event there would lose the call entirely.
+    func testAssistantWithEmptyContentStillEmitsToolCall() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFileFull(at: url))
+
+        let terminalCall = session.events.first { $0.toolName == "run_terminal_cmd" }
+        XCTAssertNotNil(terminalCall)
+        XCTAssertEqual(terminalCall?.kind, .tool_call)
+    }
+
+    func testToolResultsKeyBackToTheirCall() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFileFull(at: url))
+
+        let results = session.events.filter { $0.kind == .tool_result }
+        XCTAssertEqual(results.count, 2)
+        let ids = Set(results.compactMap { $0.messageID })
+        XCTAssertTrue(ids.contains("call-00000000-0000-4000-8000-000000000002-0"))
+        XCTAssertEqual(results.first?.toolOutput, "print(\"hello from the grok fixture\")\n")
+    }
+
+    /// Reasoning renders from `summary[].text`; `encrypted_content` is opaque
+    /// and must never surface in the transcript body.
+    func testReasoningRendersSummaryTextOnly() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFileFull(at: url))
+
+        let thinking = session.events.filter { $0.role == "thinking" }
+        XCTAssertEqual(thinking.count, 2)
+        XCTAssertEqual(thinking.first?.kind, .meta)
+        XCTAssertTrue(thinking.first?.text?.hasPrefix("[thinking] ") == true)
+        XCTAssertFalse(session.events.contains { $0.text?.contains("<opaque>") == true })
+    }
+
+    func testUserContentPartsFlattenIncludingImages() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFileFull(at: url))
+
+        let users = session.events.filter { $0.kind == .user }
+        XCTAssertEqual(users.count, 3)
+        XCTAssertEqual(users.last?.text, "[image]\nHere is a screenshot for reference.")
+    }
+
+    /// The preview pass must not report a truncated event count for list rows,
+    /// so it takes `num_chat_messages` from the sidecar instead of counting.
+    func testLightweightParseUsesSidecarMessageCount() throws {
+        let url = try stagedFixture()
+        let session = try XCTUnwrap(GrokSessionParser.parseFile(at: url))
+
+        XCTAssertEqual(session.eventCount, 11)
+        XCTAssertTrue(session.events.isEmpty)
+        XCTAssertEqual(session.lightweightCommands, 3)
+    }
+}

--- a/AgentSessionsTests/SessionParserTests.swift
+++ b/AgentSessionsTests/SessionParserTests.swift
@@ -421,6 +421,7 @@ final class SessionParserTests: XCTestCase {
                           includeCursor: false,
                           includePi: false,
                           includeKimi: false,
+                          includeGrok: false,
                           enableDeepScan: false,
                           all: [root, sideChat])
 
@@ -459,6 +460,7 @@ final class SessionParserTests: XCTestCase {
                           includeCursor: false,
                           includePi: false,
                           includeKimi: false,
+                          includeGrok: false,
                           enableDeepScan: false,
                           all: [root, sideChat])
 
@@ -489,6 +491,7 @@ final class SessionParserTests: XCTestCase {
                        includeCursor: false,
                        includePi: false,
                        includeKimi: true,
+                       includeGrok: true,
                        enableDeepScan: false,
                        all: [kimi])
 
@@ -510,6 +513,7 @@ final class SessionParserTests: XCTestCase {
                        includeCursor: false,
                        includePi: false,
                        includeKimi: false,
+                       includeGrok: false,
                        enableDeepScan: false,
                        all: [kimi, codex])
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <td>
 
 **Live per-session quota burn for Codex and Claude — see *which* session is eating your 5-hour and weekly limits, priced per model.**
-Plus a searchable history across [Codex](https://jazzyalex.github.io/agent-sessions/guides/codex-local-history.html?campaign=github&ref=readme-guide), [Claude](https://jazzyalex.github.io/agent-sessions/guides/claude-code-jsonl-history.html?campaign=github&ref=readme-guide), [OpenCode](https://jazzyalex.github.io/agent-sessions/guides/opencode-sqlite-history.html?campaign=github&ref=readme-guide), [Cursor](https://jazzyalex.github.io/agent-sessions/guides/cursor-agent-local-history.html?campaign=github&ref=readme-guide), GitHub Copilot CLI, Pi, Kimi Code, Antigravity CLI, [Hermes](https://jazzyalex.github.io/agent-sessions/guides/hermes-agent-state-db-history.html?campaign=github&ref=readme-guide), and [OpenClaw](https://jazzyalex.github.io/agent-sessions/guides/openclaw-local-agent-history.html?campaign=github&ref=readme-guide) — transcripts, images, and one-click resume. macOS, local-only.
+Plus a searchable history across [Codex](https://jazzyalex.github.io/agent-sessions/guides/codex-local-history.html?campaign=github&ref=readme-guide), [Claude](https://jazzyalex.github.io/agent-sessions/guides/claude-code-jsonl-history.html?campaign=github&ref=readme-guide), [OpenCode](https://jazzyalex.github.io/agent-sessions/guides/opencode-sqlite-history.html?campaign=github&ref=readme-guide), [Cursor](https://jazzyalex.github.io/agent-sessions/guides/cursor-agent-local-history.html?campaign=github&ref=readme-guide), GitHub Copilot CLI, Pi, Kimi Code, Grok CLI, Antigravity CLI, [Hermes](https://jazzyalex.github.io/agent-sessions/guides/hermes-agent-state-db-history.html?campaign=github&ref=readme-guide), and [OpenClaw](https://jazzyalex.github.io/agent-sessions/guides/openclaw-local-agent-history.html?campaign=github&ref=readme-guide) — transcripts, images, and one-click resume. macOS, local-only.
 
 [**Session Bench**](https://jazzyalex.github.io/agent-sessions/bench/?campaign=github&ref=readme): how ten agents' session formats score — 19 pass/fail gates, evidence behind every cell.
 
@@ -42,7 +42,7 @@ Plus a searchable history across [Codex](https://jazzyalex.github.io/agent-sessi
 
 Run three agents at once and a normal quota meter tells you "60% used" — not which one spent it. Agent Sessions attributes burn to the **individual session**, live, against your Codex and Claude 5-hour and weekly windows. Pick the lens you want (5-hour, weekly, tokens/hour, or dollars); the `$` lens prices each model in a session at its own rate, so an Opus orchestrator driving Sonnet subagents is costed per model instead of blended into one number.
 
-It's also a local-first Mac app for finding useful work coding agents already wrote to disk — Codex, Claude, OpenCode, Cursor Agent, Hermes, OpenClaw, Antigravity, GitHub Copilot CLI, Pi, and Kimi Code histories in one searchable view, with transcript inspection, image browsing, saved-session recovery, and resume commands for supported CLIs.
+It's also a local-first Mac app for finding useful work coding agents already wrote to disk — Codex, Claude, OpenCode, Cursor Agent, Hermes, OpenClaw, Antigravity, GitHub Copilot CLI, Pi, Kimi Code, and Grok CLI histories in one searchable view, with transcript inspection, image browsing, saved-session recovery, and resume commands for supported CLIs.
 
 <div align="center">
   <p style="margin:0 0 0px 0;"><em>Session Runway — live per-session quota burn-rate</em></p>

--- a/Resources/Fixtures/stage0/agents/grok/chat_history.jsonl
+++ b/Resources/Fixtures/stage0/agents/grok/chat_history.jsonl
@@ -1,0 +1,11 @@
+{"type":"system","content":"You are Grok 4.5 released by xAI. You are an interactive CLI tool that helps users with software engineering tasks."}
+{"type":"user","content":[{"type":"text","text":"<user_info>\nOS Version: macos\nWorkspace Path: /tmp/as-agent-lab/grok/project\n</user_info>"}],"synthetic_reason":"environment_context"}
+{"type":"user","content":[{"type":"text","text":"Read hello.py and summarize what it prints without editing files."}],"prompt_index":0}
+{"type":"reasoning","id":"rs_00000000-0000-4000-8000-000000000001","summary":[{"type":"summary_text","text":"The user wants a summary of hello.py without edits. I should read the file first."}],"encrypted_content":"<opaque>","status":"completed"}
+{"type":"assistant","content":"I'll read the file first.","tool_calls":[{"id":"call-00000000-0000-4000-8000-000000000002-0","name":"read_file","arguments":"{\"target_file\":\"/tmp/as-agent-lab/grok/project/hello.py\"}"}],"model_id":"grok-4.5","model_fingerprint":"fp_0000000000000000","reasoning_effort":"high"}
+{"type":"tool_result","tool_call_id":"call-00000000-0000-4000-8000-000000000002-0","content":"print(\"hello from the grok fixture\")\n"}
+{"type":"backend_tool_call","kind":{"tool_type":"web_search","action":{"type":"search","query":"python print builtin","sources":[]}}}
+{"type":"assistant","content":"","tool_calls":[{"id":"call-00000000-0000-4000-8000-000000000002-1","name":"run_terminal_cmd","arguments":"{\"command\":\"python3 hello.py\"}"}],"model_id":"grok-4.5","model_fingerprint":"fp_0000000000000000","reasoning_effort":"high"}
+{"type":"tool_result","tool_call_id":"call-00000000-0000-4000-8000-000000000002-1","content":"hello from the grok fixture\n"}
+{"type":"reasoning","id":"rs_00000000-0000-4000-8000-000000000003","summary":[{"type":"summary_text","text":"Confirmed the output. I can answer now."}],"encrypted_content":"<opaque>","status":"completed"}
+{"type":"user","content":[{"type":"image","image":{"url":"data:image/png;base64,<scrubbed>"}},{"type":"text","text":"Here is a screenshot for reference."}],"prompt_index":1}

--- a/Resources/Fixtures/stage0/agents/grok/summary.json
+++ b/Resources/Fixtures/stage0/agents/grok/summary.json
@@ -1,0 +1,27 @@
+{
+  "info": {
+    "id": "019f6851-7ec4-7ef0-97d3-03f3eee38755",
+    "cwd": "/tmp/as-agent-lab/grok/project"
+  },
+  "session_summary": "Read hello.py and summarize what it prints",
+  "created_at": "2026-07-31T10:13:27.574131Z",
+  "updated_at": "2026-07-31T10:15:02.118940Z",
+  "num_messages": 42,
+  "num_chat_messages": 11,
+  "current_model_id": "grok-4.5",
+  "next_trace_turn": 2,
+  "chat_format_version": 1,
+  "git_root_dir": "/tmp/as-agent-lab/grok/project/",
+  "git_remotes": [
+    "git@github.com:example-user/example.git"
+  ],
+  "head_commit": "0000000000000000000000000000000000000000",
+  "head_branch": "main",
+  "request_id": "00000000-0000-4000-8000-000000000000",
+  "grok_home": "/Users/agent/.grok",
+  "last_active_at": "2026-07-31T10:15:02.118940Z",
+  "generated_title": "Read hello.py and summarize what it prints",
+  "agent_name": "grok",
+  "sandbox_profile": "off",
+  "reasoning_effort": "high"
+}

--- a/docs/agent-support/agent-support-matrix.yml
+++ b/docs/agent-support/agent-support-matrix.yml
@@ -160,3 +160,24 @@ agents:
       - "AgentSessionsTests/KimiSessionParserTests.swift"
       - "AgentSessionsTests/KimiSessionDiscoveryTests.swift"
       - "AgentSessionsTests/KimiResumeCommandBuilderTests.swift"
+  grok_cli:
+    max_verified_version: "1.0.0"
+    version_field: "not_logged"
+    support_scope: "tier-2 local JSONL transcript discovery, browsing, search, Preferences controls, colors, copy-resume command, launch-in-terminal resume, and analytics"
+    unsupported_surfaces:
+      - "live/active status"
+      - "usage/rate-limit tracking"
+      - "subagent hierarchy"
+      - "weekly session-format monitoring (no agent_watch driver yet)"
+    evidence_docs:
+      - "grok --help at 1.0.0 (3cd0d0cbcebe)"
+    evidence_captures:
+      - "~/.grok/sessions/<percent-encoded workdir>/<sessionId>/ (141 sessions surveyed)"
+    evidence_fixtures:
+      - "Resources/Fixtures/stage0/agents/grok/chat_history.jsonl"
+      - "Resources/Fixtures/stage0/agents/grok/summary.json"
+    evidence_tests:
+      - "AgentSessionsTests/GrokSessionParserTests.swift"
+      - "AgentSessionsTests/GrokSessionDiscoveryTests.swift"
+    evidence_tools:
+      - "scripts/grok_chat_schema_probe.py"

--- a/docs/agent-support/public-agents.json
+++ b/docs/agent-support/public-agents.json
@@ -9,6 +9,7 @@
     { "id": "antigravity", "public_name": "Antigravity CLI" },
     { "id": "hermes", "public_name": "Hermes" },
     { "id": "openclaw", "public_name": "OpenClaw" },
-    { "id": "kimi", "public_name": "Kimi Code" }
+    { "id": "kimi", "public_name": "Kimi Code" },
+    { "id": "grok", "public_name": "Grok CLI" }
   ]
 }

--- a/scripts/grok_chat_schema_probe.py
+++ b/scripts/grok_chat_schema_probe.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Read-only schema probe for Grok CLI session stores under ~/.grok/sessions.
+
+Mirrors scripts/droid_stream_schema_probe.py: it reports the observed shape of
+the on-disk format so a parser is written against evidence rather than guesses.
+
+Usage:
+    python3 scripts/grok_chat_schema_probe.py [--root ~/.grok/sessions] [--sample N]
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import pathlib
+import sys
+
+
+def iter_sessions(root: pathlib.Path):
+    for bucket in sorted(root.iterdir()):
+        if not bucket.is_dir():
+            continue
+        for session in sorted(bucket.iterdir()):
+            if session.is_dir() and (session / "summary.json").exists():
+                yield bucket, session
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default="~/.grok/sessions")
+    ap.add_argument("--sample", type=int, default=0, help="limit sessions scanned")
+    args = ap.parse_args()
+
+    root = pathlib.Path(os.path.expanduser(args.root))
+    if not root.is_dir():
+        print(f"no such root: {root}", file=sys.stderr)
+        return 1
+
+    sessions = list(iter_sessions(root))
+    if args.sample:
+        sessions = sessions[: args.sample]
+
+    print(f"root: {root}")
+    print(f"sessions with summary.json: {len(sessions)}")
+
+    summary_keys = collections.Counter()
+    file_presence = collections.Counter()
+    chat_types = collections.Counter()
+    content_shapes = collections.Counter()
+    format_versions = collections.Counter()
+    models = collections.Counter()
+    missing_chat = 0
+
+    for _bucket, session in sessions:
+        for entry in session.iterdir():
+            file_presence[entry.name] += 1
+
+        try:
+            summary = json.loads((session / "summary.json").read_text())
+        except Exception:
+            continue
+        for k in summary:
+            summary_keys[k] += 1
+        format_versions[summary.get("chat_format_version")] += 1
+        if summary.get("current_model_id"):
+            models[summary["current_model_id"]] += 1
+
+        chat = session / "chat_history.jsonl"
+        if not chat.exists():
+            missing_chat += 1
+            continue
+        with chat.open(errors="replace") as fh:
+            for line in fh:
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    chat_types["UNPARSEABLE"] += 1
+                    continue
+                t = obj.get("type", "?")
+                chat_types[t] += 1
+                content = obj.get("content")
+                if isinstance(content, str):
+                    content_shapes[f"{t}:str"] += 1
+                elif isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict):
+                            content_shapes[f"{t}:{part.get('type', '?')}"] += 1
+                elif content is None:
+                    content_shapes[f"{t}:none"] += 1
+
+    def dump(title, counter, limit=25):
+        print(f"\n--- {title} ---")
+        for k, v in counter.most_common(limit):
+            print(f"  {str(k):<34} {v}")
+
+    print(f"\nsessions missing chat_history.jsonl: {missing_chat}")
+    dump("summary.json keys", summary_keys)
+    dump("chat_format_version", format_versions)
+    dump("current_model_id", models)
+    dump("files present in session dirs", file_presence, 30)
+    dump("chat_history record types", chat_types)
+    dump("content part shapes (type:part)", content_shapes, 30)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds Grok CLI as a session source at tier-2 scope: discovery, parsing, browsing, search, Analytics, Preferences pane, colors, copy-resume and launch-in-terminal resume.

## Format, and why the transcript rather than the journal

A Grok session directory is `~/.grok/sessions/<percent-encoded workdir>/<sessionId>/`, holding `summary.json` (sidecar) beside `chat_history.jsonl` (transcript) and a much larger `updates.jsonl` event journal.

The transcript is the discovery unit. Both files carry the same conversation, but the journal re-encodes it as streaming ACP updates where each `tool_call_update` repeats the entire accumulated tool output instead of a delta — in the largest session on this machine that is **2.3 GB against 1.2 MB** for the identical transcript.

Schema verified with `scripts/grok_chat_schema_probe.py` across **141 real sessions** at CLI 1.0.0 (`3cd0d0cbcebe`), all reporting `chat_format_version: 1`:

| record | shape |
|---|---|
| `system` | one per session, `content` is the system prompt string |
| `user` | `content` is an array of `text` / `image` parts; `prompt_index` marks a genuine turn, `synthetic_reason` an injected one |
| `assistant` | `content` is a plain string, plus `model_id`, `model_fingerprint`, `reasoning_effort`, optional `tool_calls` of `{id, name, arguments}` where `arguments` is a JSON *string* |
| `reasoning` | readable rationale in `summary[].text`; `encrypted_content` is opaque and never surfaces |
| `tool_result` | `content` keyed back by `tool_call_id`, optional `images` |
| `backend_tool_call` | server-side tools (web search) under `kind`, with no matching `tool_result` |

The transcript carries no per-record timestamps, so both session bounds come from the sidecar's RFC 3339 fields. Title prefers `generated_title`, then `session_summary`, then the first non-synthetic prompt.

## Three things a straight port of the Kimi source would have got wrong

1. **Grok does have `--resume`.** Kimi's files document the opposite for their own CLI, so the resume ladder here is resume-then-continue, and `GrokCLIEnvironment` probes `supportsResume` rather than `supportsSession`. `--resume` documents that "UUID-shaped values always mean IDs", so the bare session-directory name resolves unambiguously and never falls back to title matching.

2. **`grok` on Homebrew is a different program.** The formula is jordansissel/grok, a regex utility; the CLI arrives as the `grok-build` *cask*. So `binaryInstalled(for: .grok)` requires `~/.grok` to exist alongside the binary, `GrokCLIEnvironment` only accepts a candidate whose `--help` advertises the resume flags, and `AgentUpdateService.profile(for: .grok)` deliberately returns `nil` — a brew mapping there would upgrade the wrong package.

3. **Discovery walks exactly two levels.** Session directories contain `subagents/`, `terminal/` and `compaction/` subtrees; a recursive scan surfaces nested transcripts as if they were top-level sessions. There is a regression test for this.

## Tests

15 new tests across `GrokSessionParserTests` and `GrokSessionDiscoveryTests`, covering sidecar identity, sidecar-derived timestamps, tool-call extraction (including an assistant record with empty `content` but live `tool_calls`), tool-result keying, reasoning rendering from `summary[].text` only, image content parts, the sidecar-backed lightweight message count, and the four discovery rejection cases.

The fixture reproduces the verified schema rather than embedding a real capture. I first tried scrubbing a genuine session and it still left an email address and percent-encoded home paths in free-form prose, which is not something to put in a public repo.

Two existing aggregation tests (`CodexActiveSessionsRegistryTests`, `SessionParserTests`) gained the new `grokList` / `grok` / `includeGrok` arguments.

## Test plan

- `xcodebuild … clean build` — **BUILD SUCCEEDED**, 0 errors, from a wiped derived-data directory.
- Full suite: **1,887 tests, 5 failures**. All 5 are pre-existing and environment-dependent — I reproduced the identical set on a clean `upstream/main` worktree on this machine: `AgentBinaryDetectionTests.testBinaryInstalledForClaude_acceptsClaudeCodeBinaryName`, `CopyResumeCommandTests.testAntigravity_conversationID_and_cwd`, `CursorSessionParserTests.testInferCWDBestEffortReturnsDecodedPathWhenFinalDirectoryMissing`, `CursorSettingsTests.testEffectiveWorkingDirectoryFallsBackToBestEffortFromFilePath`.
- New Grok tests: 15 passed, 0 failures.

## Notes for review

- `SessionSource.versionIntroduced` is set to `"4.8"`; change it if that is not the next release.
- No `agent_watch` prebump driver, so `unsupported_surfaces` in the matrix records the absence of weekly monitoring rather than claiming it.
- README changes are limited to the two "which agents does this read" lists. I did not write a "New in 4.8" section — that is yours.
- `docs/agent-support/agent-support-ledger.yml` has no entry yet; I did not want to author a verification ledger entry in your voice, but happy to add one in whatever form you prefer.

Devin is the other absent source with a large local store here (a single 5.4 GB SQLite `sessions.db`). Its format is completely different — a `message_nodes` forest rather than JSONL — so it belongs in its own PR. Glad to do that next if this shape is right.
