### PR TITLE
Fix OpenCode mtime normalization and migrate existing index rows

### DIFF
--- a/AgentSessions/Indexing/DB.swift
+++ b/AgentSessions/Indexing/DB.swift
@@ -521,16 +521,15 @@ actor IndexDB {
             try execBind(db, "INSERT OR IGNORE INTO schema_migrations(key) VALUES(?);", claudeWorkflowReindex)
         }
 
-        // OpenCode session_meta.mtime was written on the millisecond scale while
-        // start_ts/end_ts stayed seconds, so COALESCE(end_ts, mtime) ordering and
-        // date filters mixed units and every OpenCode row misdated (mtime treated
-        // as ~year 58k under unixepoch seconds). The ingest writer is fixed; this
-        // one-time marker rebuilds the already-indexed OpenCode rows so existing
-        // databases are repaired on launch instead of only new ingests.
-        let opencodeMtimeReindex = "opencode_mtime_reindex_v1"
-        if !migrationApplied(db, key: opencodeMtimeReindex) {
-            try reindexSessionMeta(db, sources: ["opencode"])
-            try execBind(db, "INSERT OR IGNORE INTO schema_migrations(key) VALUES(?);", opencodeMtimeReindex)
+        // Identity-backed sources historically wrote their millisecond logical revision
+        // into session_meta.mtime, while the rest of session_meta uses Unix seconds.
+        // Repair those rows in place for every source. This preserves the search corpus,
+        // works for currently disabled providers, and leaves session_days.meta_mtime stale
+        // so the analytics refresh naturally re-derives affected day rows.
+        let sessionMetaMtimeSeconds = "session_meta_mtime_seconds_v1"
+        if !migrationApplied(db, key: sessionMetaMtimeSeconds) {
+            try exec(db, "UPDATE session_meta SET mtime = mtime / 1000 WHERE mtime >= 1000000000000;")
+            try execBind(db, "INSERT OR IGNORE INTO schema_migrations(key) VALUES(?);", sessionMetaMtimeSeconds)
         }
 
         // Re-derive Codex session_meta so guardian approval-reviewer subagents

--- a/AgentSessions/Indexing/DB.swift
+++ b/AgentSessions/Indexing/DB.swift
@@ -521,6 +521,18 @@ actor IndexDB {
             try execBind(db, "INSERT OR IGNORE INTO schema_migrations(key) VALUES(?);", claudeWorkflowReindex)
         }
 
+        // OpenCode session_meta.mtime was written on the millisecond scale while
+        // start_ts/end_ts stayed seconds, so COALESCE(end_ts, mtime) ordering and
+        // date filters mixed units and every OpenCode row misdated (mtime treated
+        // as ~year 58k under unixepoch seconds). The ingest writer is fixed; this
+        // one-time marker rebuilds the already-indexed OpenCode rows so existing
+        // databases are repaired on launch instead of only new ingests.
+        let opencodeMtimeReindex = "opencode_mtime_reindex_v1"
+        if !migrationApplied(db, key: opencodeMtimeReindex) {
+            try reindexSessionMeta(db, sources: ["opencode"])
+            try execBind(db, "INSERT OR IGNORE INTO schema_migrations(key) VALUES(?);", opencodeMtimeReindex)
+        }
+
         // Re-derive Codex session_meta so guardian approval-reviewer subagents
         // ({"subagent":{"other":"guardian"}}) get subagent_type/parent_session_id
         // populated by the fixed SessionIndexer extraction, and internal session

--- a/AgentSessions/Search/SearchIngestService.swift
+++ b/AgentSessions/Search/SearchIngestService.swift
@@ -131,6 +131,14 @@ actor SearchIngestService {
         let dbGeneration: Int64
     }
 
+    /// session_meta timestamps (mtime, start_ts, end_ts) are seconds-scaled.
+    /// Providers that report milliseconds (OpenCode session.time_updated) must be
+    /// normalized before reaching the index, or COALESCE(end_ts, mtime) ordering
+    /// and date filters mix units and rows misdate.
+    nonisolated static func normalizedMtime(_ value: Int64) -> Int64 {
+        value >= 1_000_000_000_000 ? value / 1_000 : value
+    }
+
     nonisolated static func contentRevision(for session: Session) -> ContentRevision {
         let updated = session.endTime ?? session.startTime ?? Date(timeIntervalSince1970: 0)
         return ContentRevision(updatedMillis: Int64((updated.timeIntervalSince1970 * 1_000.0).rounded()),
@@ -303,9 +311,17 @@ actor SearchIngestService {
 
             let pathIsCurrent = indexedByPath[file.path].map { $0.mtime == file.mtime && $0.size == file.size } ?? false
             let identityIsCurrent = file.sessionID.flatMap { id in
-                file.contentRevision.map {
-                    searchIdentityStatesBySessionID[id]?.storagePath == file.path
-                        && searchIdentityStatesBySessionID[id]?.revision == $0
+                file.contentRevision.map { revision -> Bool in
+                    guard let state = searchIdentityStatesBySessionID[id],
+                          state.storagePath == file.path,
+                          state.revision.updatedMillis == revision.updatedMillis else { return false }
+                    // A stored revision on the seconds scale while the provider
+                    // reports milliseconds marks a pre-normalization legacy row
+                    // (OpenCode session.time_updated used to reach session_meta
+                    // unconverted). Force one re-ingest so session_meta mtime is
+                    // rewritten on the seconds scale.
+                    return Self.normalizedMtime(revision.updatedMillis) == revision.updatedMillis
+                        || revision.updatedMillis >= 1_000_000_000_000
                 }
             }
             let isCurrent = identityIsCurrent ?? pathIsCurrent
@@ -320,9 +336,10 @@ actor SearchIngestService {
                 // when the path has no `session_meta` row yet (refTSByPath lookup miss);
                 // `isCurrent`/`searchReadyPaths` already guarantee a row exists in that
                 // case in practice, but the fallback keeps this branch safe regardless.
-                let refTS = file.sessionID.flatMap { refTSBySessionID[$0] }
-                    ?? refTSByPath[file.path]
-                    ?? file.mtime
+                let refTS = Self.normalizedMtime(
+                    file.sessionID.flatMap { refTSBySessionID[$0] }
+                        ?? refTSByPath[file.path]
+                        ?? file.mtime)
                 let outsideToolIOWindow = refTS < toolIOCutoffTS
                 let toolIOIsReady = file.sessionID.flatMap { id in
                     file.contentRevision.map {
@@ -526,8 +543,11 @@ actor SearchIngestService {
             // For shared SQLite storage, analytics freshness must follow the logical
             // session revision rather than the database file stat (which can remain
             // unchanged while writes live in the WAL). Ordinary files still resolve
-            // these accessors to their physical mtime/size.
-            mtime: file.searchMtime,
+            // these accessors to their physical mtime/size. `normalizedMtime` also
+            // collapses any provider that reports milliseconds (OpenCode
+            // session.time_updated) into the seconds scale session_meta uses, so
+            // COALESCE(end_ts, mtime) ordering and date filters cannot mix units.
+            mtime: Self.normalizedMtime(file.searchMtime),
             size: file.searchSize,
             startTS: Int64(start.timeIntervalSince1970),
             endTS: Int64(end.timeIntervalSince1970),

--- a/AgentSessions/Search/SearchIngestService.swift
+++ b/AgentSessions/Search/SearchIngestService.swift
@@ -131,10 +131,10 @@ actor SearchIngestService {
         let dbGeneration: Int64
     }
 
-    /// session_meta timestamps (mtime, start_ts, end_ts) are seconds-scaled.
-    /// Providers that report milliseconds (OpenCode session.time_updated) must be
-    /// normalized before reaching the index, or COALESCE(end_ts, mtime) ordering
-    /// and date filters mix units and rows misdate.
+    /// `session_meta` timestamps (`mtime`, `start_ts`, `end_ts`) are seconds-scaled.
+    /// Identity-backed providers report their logical revision in milliseconds, so
+    /// normalize only the value written to `session_meta.mtime`. The search and tool-I/O
+    /// tables deliberately retain the millisecond revision used by the ingest skip gate.
     nonisolated static func normalizedMtime(_ value: Int64) -> Int64 {
         value >= 1_000_000_000_000 ? value / 1_000 : value
     }
@@ -311,17 +311,9 @@ actor SearchIngestService {
 
             let pathIsCurrent = indexedByPath[file.path].map { $0.mtime == file.mtime && $0.size == file.size } ?? false
             let identityIsCurrent = file.sessionID.flatMap { id in
-                file.contentRevision.map { revision -> Bool in
-                    guard let state = searchIdentityStatesBySessionID[id],
-                          state.storagePath == file.path,
-                          state.revision.updatedMillis == revision.updatedMillis else { return false }
-                    // A stored revision on the seconds scale while the provider
-                    // reports milliseconds marks a pre-normalization legacy row
-                    // (OpenCode session.time_updated used to reach session_meta
-                    // unconverted). Force one re-ingest so session_meta mtime is
-                    // rewritten on the seconds scale.
-                    return Self.normalizedMtime(revision.updatedMillis) == revision.updatedMillis
-                        || revision.updatedMillis >= 1_000_000_000_000
+                file.contentRevision.map {
+                    searchIdentityStatesBySessionID[id]?.storagePath == file.path
+                        && searchIdentityStatesBySessionID[id]?.revision == $0
                 }
             }
             let isCurrent = identityIsCurrent ?? pathIsCurrent
@@ -336,10 +328,9 @@ actor SearchIngestService {
                 // when the path has no `session_meta` row yet (refTSByPath lookup miss);
                 // `isCurrent`/`searchReadyPaths` already guarantee a row exists in that
                 // case in practice, but the fallback keeps this branch safe regardless.
-                let refTS = Self.normalizedMtime(
-                    file.sessionID.flatMap { refTSBySessionID[$0] }
-                        ?? refTSByPath[file.path]
-                        ?? file.mtime)
+                let refTS = file.sessionID.flatMap { refTSBySessionID[$0] }
+                    ?? refTSByPath[file.path]
+                    ?? file.mtime
                 let outsideToolIOWindow = refTS < toolIOCutoffTS
                 let toolIOIsReady = file.sessionID.flatMap { id in
                     file.contentRevision.map {
@@ -543,10 +534,9 @@ actor SearchIngestService {
             // For shared SQLite storage, analytics freshness must follow the logical
             // session revision rather than the database file stat (which can remain
             // unchanged while writes live in the WAL). Ordinary files still resolve
-            // these accessors to their physical mtime/size. `normalizedMtime` also
-            // collapses any provider that reports milliseconds (OpenCode
-            // session.time_updated) into the seconds scale session_meta uses, so
-            // COALESCE(end_ts, mtime) ordering and date filters cannot mix units.
+            // these accessors to their physical mtime/size. Normalize only the
+            // session_meta write; session_search/session_tool_io keep the original
+            // identity revision so their skip-gate comparisons remain stable.
             mtime: Self.normalizedMtime(file.searchMtime),
             size: file.searchSize,
             startTS: Int64(start.timeIntervalSince1970),

--- a/AgentSessionsTests/Indexing/MigrationCorpusPreservationTests.swift
+++ b/AgentSessionsTests/Indexing/MigrationCorpusPreservationTests.swift
@@ -14,16 +14,20 @@ import XCTest
 /// these tests fail.
 final class MigrationCorpusPreservationTests: XCTestCase {
 
-    private func seedSession(_ db: IndexDB, source: String, id: String) async throws {
+    private func seedSession(_ db: IndexDB,
+                             source: String,
+                             id: String,
+                             metaMtime: Int64 = 100,
+                             searchMtime: Int64 = 100) async throws {
         try await db.upsertSessionMeta(SessionMetaRow(
             sessionID: id, source: source, path: "/tmp/\(id).jsonl",
-            mtime: 100, size: 200, startTS: 100, endTS: 200,
+            mtime: metaMtime, size: 200, startTS: 100, endTS: 200,
             model: nil, cwd: nil, repo: nil, title: "t",
             codexInternalSessionID: nil, isHousekeeping: false,
             messages: 3, commands: 1,
             parentSessionID: nil, subagentType: nil, customTitle: nil))
         try await db.upsertSessionSearch(sessionID: id, source: source,
-            mtime: 100, size: 200, text: "hello \(source) searchable")
+            mtime: searchMtime, size: 200, text: "hello \(source) searchable")
         try await db.upsertSessionToolIO(sessionID: id, source: source,
             mtime: 100, size: 200, refTS: 200, text: "tool io \(source)")
     }
@@ -137,10 +141,10 @@ final class MigrationCorpusPreservationTests: XCTestCase {
         }
     }
 
-    /// Locks the OpenCode mtime normalization marker: on a populated install it
-    /// rebuilds ONLY opencode session_meta (so the next provider refresh rewrites
-    /// mtime on the seconds scale) and never touches the FTS corpus or other sources.
-    func testBootstrapOpenCodeMtimeReindexMarkerPreservesCorpusOnPopulatedDatabase() async throws {
+    /// Locks the in-place mtime migration: millisecond-scale session_meta rows are
+    /// converted for every source, seconds-scale rows and row counts stay unchanged,
+    /// and session_search retains the millisecond identity revision used by ingest.
+    func testBootstrapSessionMetaMtimeMigrationNormalizesAllSourcesInPlace() async throws {
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("AgentSessionsTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
@@ -153,28 +157,63 @@ final class MigrationCorpusPreservationTests: XCTestCase {
         var db: IndexDB? = try IndexDB()
         IndexDBTestHooks.applicationSupportDirectoryProvider = originalProvider
 
-        try await seedSession(db!, source: "opencode", id: "opencode-1")
-        try await seedSession(db!, source: "claude", id: "claude-1")
+        let millis: Int64 = 1_776_370_012_000
+        let seconds: Int64 = 1_776_370_012
+        try await seedSession(db!, source: "opencode", id: "opencode-ms",
+                              metaMtime: millis, searchMtime: millis)
+        try await seedSession(db!, source: "hermes", id: "hermes-ms",
+                              metaMtime: millis, searchMtime: millis)
+        try await seedSession(db!, source: "opencode", id: "opencode-seconds",
+                              metaMtime: seconds, searchMtime: seconds)
+        try await seedSession(db!, source: "claude", id: "claude-seconds",
+                              metaMtime: seconds, searchMtime: seconds)
+        try await db!.begin()
+        for source in ["opencode", "hermes", "claude"] {
+            _ = try await db!.populateSessionDaysFromMeta(for: source)
+        }
+        try await db!.commit()
 
         // Simulate the upgrade where this marker has never run.
-        try await db!.exec("DELETE FROM schema_migrations WHERE key = 'opencode_mtime_reindex_v1';")
+        try await db!.exec("DELETE FROM schema_migrations WHERE key = 'session_meta_mtime_seconds_v1';")
         db = nil
 
         IndexDBTestHooks.applicationSupportDirectoryProvider = { tmpDir }
         let reopened = try IndexDB()
         IndexDBTestHooks.applicationSupportDirectoryProvider = originalProvider
 
-        let opencodeMeta = try await reopened.rowCountForTesting(table: "session_meta", source: "opencode")
-        let claudeMeta = try await reopened.rowCountForTesting(table: "session_meta", source: "claude")
-        XCTAssertEqual(opencodeMeta, 0, "bootstrap's opencode_mtime_reindex_v1 marker should clear opencode session_meta")
-        XCTAssertEqual(claudeMeta, 1, "the marker must not touch claude session_meta")
+        let metaCount = try await reopened.rowCountForTesting(table: "session_meta")
+        let searchCount = try await reopened.rowCountForTesting(table: "session_search")
+        let toolIOCount = try await reopened.rowCountForTesting(table: "session_tool_io")
+        let dayCount = try await reopened.rowCountForTesting(table: "session_days")
+        XCTAssertEqual(metaCount, 4)
+        XCTAssertEqual(searchCount, 4)
+        XCTAssertEqual(toolIOCount, 4)
+        XCTAssertEqual(dayCount, 4)
 
-        for source in ["opencode", "claude"] {
-            let search = try await reopened.rowCountForTesting(table: "session_search", source: source)
-            let toolIO = try await reopened.rowCountForTesting(table: "session_tool_io", source: source)
-            XCTAssertEqual(search, 1, "session_search[\(source)] must survive bootstrap's opencode mtime reindex marker")
-            XCTAssertEqual(toolIO, 1, "session_tool_io[\(source)] must survive bootstrap's opencode mtime reindex marker")
-        }
+        let opencodeMeta = Dictionary(uniqueKeysWithValues:
+            try await reopened.fetchSessionMeta(for: "opencode").map { ($0.sessionID, $0.mtime) })
+        let hermesMeta = Dictionary(uniqueKeysWithValues:
+            try await reopened.fetchSessionMeta(for: "hermes").map { ($0.sessionID, $0.mtime) })
+        let claudeMeta = Dictionary(uniqueKeysWithValues:
+            try await reopened.fetchSessionMeta(for: "claude").map { ($0.sessionID, $0.mtime) })
+        XCTAssertEqual(opencodeMeta["opencode-ms"], seconds)
+        XCTAssertEqual(hermesMeta["hermes-ms"], seconds)
+        XCTAssertEqual(opencodeMeta["opencode-seconds"], seconds)
+        XCTAssertEqual(claudeMeta["claude-seconds"], seconds)
+
+        let opencodeSearch = try await reopened.sessionSearchIdentityStatesByID(for: "opencode")
+        let hermesSearch = try await reopened.sessionSearchIdentityStatesByID(for: "hermes")
+        XCTAssertEqual(opencodeSearch["opencode-ms"]?.revision.updatedMillis, millis,
+                       "session_search must retain the millisecond identity revision")
+        XCTAssertEqual(hermesSearch["hermes-ms"]?.revision.updatedMillis, millis,
+                       "the migration must not normalize identity revisions")
+
+        let opencodeDayUpdates = try await reopened.findSessionsNeedingDayUpdate(source: "opencode")
+        let hermesDayUpdates = try await reopened.findSessionsNeedingDayUpdate(source: "hermes")
+        let claudeDayUpdates = try await reopened.findSessionsNeedingDayUpdate(source: "claude")
+        XCTAssertEqual(opencodeDayUpdates, ["opencode-ms"])
+        XCTAssertEqual(hermesDayUpdates, ["hermes-ms"])
+        XCTAssertTrue(claudeDayUpdates.isEmpty)
     }
 }
 #endif

--- a/AgentSessionsTests/Indexing/MigrationCorpusPreservationTests.swift
+++ b/AgentSessionsTests/Indexing/MigrationCorpusPreservationTests.swift
@@ -136,5 +136,45 @@ final class MigrationCorpusPreservationTests: XCTestCase {
             XCTAssertEqual(toolIO, 1, "session_tool_io[\(source)] must survive bootstrap's codex guardian reindex marker")
         }
     }
+
+    /// Locks the OpenCode mtime normalization marker: on a populated install it
+    /// rebuilds ONLY opencode session_meta (so the next provider refresh rewrites
+    /// mtime on the seconds scale) and never touches the FTS corpus or other sources.
+    func testBootstrapOpenCodeMtimeReindexMarkerPreservesCorpusOnPopulatedDatabase() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentSessionsTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let originalProvider = IndexDBTestHooks.applicationSupportDirectoryProvider
+        defer { IndexDBTestHooks.applicationSupportDirectoryProvider = originalProvider }
+
+        IndexDBTestHooks.applicationSupportDirectoryProvider = { tmpDir }
+        var db: IndexDB? = try IndexDB()
+        IndexDBTestHooks.applicationSupportDirectoryProvider = originalProvider
+
+        try await seedSession(db!, source: "opencode", id: "opencode-1")
+        try await seedSession(db!, source: "claude", id: "claude-1")
+
+        // Simulate the upgrade where this marker has never run.
+        try await db!.exec("DELETE FROM schema_migrations WHERE key = 'opencode_mtime_reindex_v1';")
+        db = nil
+
+        IndexDBTestHooks.applicationSupportDirectoryProvider = { tmpDir }
+        let reopened = try IndexDB()
+        IndexDBTestHooks.applicationSupportDirectoryProvider = originalProvider
+
+        let opencodeMeta = try await reopened.rowCountForTesting(table: "session_meta", source: "opencode")
+        let claudeMeta = try await reopened.rowCountForTesting(table: "session_meta", source: "claude")
+        XCTAssertEqual(opencodeMeta, 0, "bootstrap's opencode_mtime_reindex_v1 marker should clear opencode session_meta")
+        XCTAssertEqual(claudeMeta, 1, "the marker must not touch claude session_meta")
+
+        for source in ["opencode", "claude"] {
+            let search = try await reopened.rowCountForTesting(table: "session_search", source: source)
+            let toolIO = try await reopened.rowCountForTesting(table: "session_tool_io", source: source)
+            XCTAssertEqual(search, 1, "session_search[\(source)] must survive bootstrap's opencode mtime reindex marker")
+            XCTAssertEqual(toolIO, 1, "session_tool_io[\(source)] must survive bootstrap's opencode mtime reindex marker")
+        }
+    }
 }
 #endif


### PR DESCRIPTION
## Authorship disclosure

This contribution, including the investigation, implementation, tests, PR description, and follow-up responses, was prepared and submitted by an OpenAI Codex coding agent operating on behalf of `Rajeev-SG`. Rajeev authorized the work and takes responsibility for the contribution.

## Problem

Identity-backed providers can expose a logical session revision in milliseconds, while `session_meta.mtime`, `start_ts`, and `end_ts` use Unix seconds. OpenCode, Hermes, and Devin all pass through the shared identity-backed ingest path, so existing `session_meta` rows can contain mixed timestamp units.

This is a real schema-unit inconsistency, but the originally reported visible ordering/date-filter symptom is not claimed here: production consumers normally read `COALESCE(end_ts, mtime)`, and indexed rows generally have a non-null `end_ts`.

## Fix

- Normalize the identity revision only when writing `session_meta.mtime`.
- Keep `session_search.mtime` and `session_tool_io.mtime` in milliseconds because they are the stored identity revision used by ingest freshness checks.
- Repair existing rows in place with a source-agnostic migration:

  ```sql
  UPDATE session_meta
  SET mtime = mtime / 1000
  WHERE mtime >= 1000000000000;
  ```

  This covers OpenCode, Hermes, Devin, disabled providers, and future identity-backed sources without deleting or reparsing indexed sessions.
- Preserve the full two-part `ContentRevision` comparison (`updatedMillis` plus `extent`) so same-timestamp message-count changes still trigger re-ingest and analytics refresh.
- Leave `session_days.meta_mtime` unchanged during migration so the existing analytics freshness query naturally schedules affected rows for re-derivation.

## Testing

Ran the maintainer-provided targeted command with local code signing disabled:

```bash
xcodebuild -project AgentSessions.xcodeproj -scheme AgentSessions \
  -configuration Debug -destination 'platform=macOS,arch=arm64' \
  -derivedDataPath .deriveddata-tests -parallel-testing-enabled NO \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:AgentSessionsTests/SessionParserTests/testOpenCodeSQLiteSearchIngestTracksIdentityUpdatesAndRemoval \
  -only-testing:AgentSessionsTests/MigrationCorpusPreservationTests test
```

Result: 5 tests passed, 0 failures.

The migration regression covers millisecond-scale OpenCode and Hermes rows, unchanged seconds-scale rows, preserved table row counts, retained millisecond search revisions, and analytics re-derivation eligibility.
