### PR TITLE
feat: add Simplified Chinese localization

### DIFF
--- a/AgentSessions/Resources/InfoPlist.xcstrings
+++ b/AgentSessions/Resources/InfoPlist.xcstrings
@@ -9,6 +9,12 @@
             "state" : "translated",
             "value" : "Agent Sessions"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent Sessions"
+          }
         }
       }
     },
@@ -16,6 +22,12 @@
       "comment" : "The short bundle name used by system UI. Keep Agent Sessions unchanged as the product name.",
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent Sessions"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agent Sessions"
@@ -31,6 +43,12 @@
             "state" : "translated",
             "value" : "Agent Sessions controls Terminal to resume Codex sessions on your behalf."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent Sessions 会控制 Terminal，代你继续 Codex 会话。"
+          }
         }
       }
     },
@@ -41,6 +59,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agent Sessions saves exported images and terminal recordings to your Downloads folder."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent Sessions 会将导出的图像和终端录制保存到“下载”文件夹。"
           }
         }
       }
@@ -53,6 +77,12 @@
             "state" : "translated",
             "value" : "Agent Sessions needs access to read session files in this location."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent Sessions 需要访问此位置，以读取其中的会话文件。"
+          }
         }
       }
     },
@@ -63,6 +93,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agent Sessions needs access to read session files in this location."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent Sessions 需要访问此位置，以读取其中的会话文件。"
           }
         }
       }

--- a/AgentSessions/Resources/Localizable.xcstrings
+++ b/AgentSessions/Resources/Localizable.xcstrings
@@ -891,7 +891,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "查找父对话串"
+            "value": "查找父对话"
           }
         }
       }

--- a/AgentSessions/Resources/Localizable.xcstrings
+++ b/AgentSessions/Resources/Localizable.xcstrings
@@ -9,6 +9,12 @@
             "state": "translated",
             "value": "%@ 5h is back again"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的 5h 额度已恢复"
+          }
         }
       }
     },
@@ -19,6 +25,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 5h limit is exhausted"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的 5h 额度已用尽"
           }
         }
       }
@@ -31,6 +43,12 @@
             "state": "translated",
             "value": "%@ 5h usage is burning fast"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的 5h 额度消耗过快"
+          }
         }
       }
     },
@@ -41,6 +59,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 5h usage is low"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的 5h 剩余额度较低"
           }
         }
       }
@@ -53,6 +77,12 @@
             "state": "translated",
             "value": "%@ weekly limit is exhausted"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的每周额度已用尽"
+          }
         }
       }
     },
@@ -64,6 +94,12 @@
             "state": "translated",
             "value": "%@ weekly usage is burning fast"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的每周额度消耗过快"
+          }
         }
       }
     },
@@ -74,6 +110,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ weekly usage is low"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的每周剩余额度较低"
           }
         }
       }
@@ -98,6 +140,24 @@
               }
             }
           }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "找到 %lld 个会话"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "找到 %lld 个会话"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -108,6 +168,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$lld%% remaining, burning to empty in about %2$@, reset in %3$@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剩余 %1$lld%%，按当前速度约 %2$@后用尽，将于 %3$@后重置。"
           }
         }
       }
@@ -120,6 +186,12 @@
             "state": "translated",
             "value": "%1$lld%% remaining, burning to empty in about %2$@."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剩余 %1$lld%%，按当前速度约 %2$@后用尽。"
+          }
         }
       }
     },
@@ -130,6 +202,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$lld%% remaining, for the 5h limit, reset in %2$@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5h 额度剩余 %1$lld%%，将于 %2$@后重置。"
           }
         }
       }
@@ -142,6 +220,12 @@
             "state": "translated",
             "value": "%lld%% remaining, for the 5h limit."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5h 额度剩余 %lld%%。"
+          }
         }
       }
     },
@@ -152,6 +236,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$lld%% remaining, for the weekly limit, reset in %2$@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每周额度剩余 %1$lld%%，将于 %2$@后重置。"
           }
         }
       }
@@ -164,6 +254,12 @@
             "state": "translated",
             "value": "%lld%% remaining, for the weekly limit."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每周额度剩余 %lld%%。"
+          }
         }
       }
     },
@@ -174,6 +270,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "0% remaining."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剩余 0%。"
           }
         }
       }
@@ -186,6 +288,12 @@
             "state": "translated",
             "value": "0%% remaining. Reset in %@."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剩余 0%%。将于 %@后重置。"
+          }
         }
       }
     },
@@ -195,6 +303,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "A couple of useful settings are easy to miss."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还有几个实用设置容易被忽略。"
           }
         }
       }
@@ -207,6 +321,12 @@
             "state": "translated",
             "value": "About Agent Sessions"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于 Agent Sessions"
+          }
         }
       }
     },
@@ -217,6 +337,12 @@
             "state": "translated",
             "value": "Adjust text size"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "调整文字大小"
+          }
         }
       }
     },
@@ -224,6 +350,12 @@
       "comment": "Product name shown in app-owned UI; keep the product name unchanged.",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent Sessions"
+          }
+        },
+        "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "Agent Sessions"
@@ -238,6 +370,12 @@
             "state": "translated",
             "value": "Agent Sessions can combine multiple local agent histories."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent Sessions 可以整合多个本地智能体的历史记录。"
+          }
         }
       }
     },
@@ -249,6 +387,12 @@
             "state": "translated",
             "value": "Agent Sessions now prioritizes Unified and Cockpit responsiveness.\nAnalytics indexing starts only when you open Analytics and press Build."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent Sessions 现在会优先保证统一视图和监控台的响应速度。\n仅当你打开“分析”并点按“构建”后，才会开始建立分析索引。"
+          }
         }
       }
     },
@@ -258,6 +402,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Agent Sources"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能体来源"
           }
         }
       }
@@ -270,6 +420,12 @@
             "state": "translated",
             "value": "Analytics Is Now On Demand"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析功能现已改为按需运行"
+          }
         }
       }
     },
@@ -279,6 +435,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Archived Sessions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已归档会话"
           }
         }
       }
@@ -291,6 +453,12 @@
             "state": "translated",
             "value": "Back"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回"
+          }
         }
       }
     },
@@ -300,6 +468,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Browse one unified list"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览统一列表"
           }
         }
       }
@@ -311,6 +485,12 @@
             "state": "translated",
             "value": "Change transcript view"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换对话记录视图"
+          }
         }
       }
     },
@@ -320,6 +500,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Check for Updates…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新…"
           }
         }
       }
@@ -331,6 +517,12 @@
             "state": "translated",
             "value": "Choose active agents"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择启用的智能体"
+          }
         }
       }
     },
@@ -340,6 +532,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Claude Code workflows stay readable."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code 工作流依然清晰易读。"
           }
         }
       }
@@ -352,6 +550,12 @@
             "state": "translated",
             "value": "Click the archive icon on the Codex filter (Command-1) to narrow to archived Desktop sessions."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点按 Codex 筛选器上的归档图标（Command-1），只查看已归档的 Desktop 会话。"
+          }
         }
       }
     },
@@ -361,6 +565,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cockpit Workflow"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "监控台工作流"
           }
         }
       }
@@ -372,6 +582,12 @@
             "state": "translated",
             "value": "Cockpit rows expose useful session context."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "监控台中的每一行都会显示实用的会话上下文。"
+          }
         }
       }
     },
@@ -381,6 +597,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Codex Desktop side chats are recoverable."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex Desktop 支线对话可以找回。"
           }
         }
       }
@@ -392,6 +614,12 @@
             "state": "translated",
             "value": "Collapse All"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部折叠"
+          }
         }
       }
     },
@@ -401,6 +629,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Copy Resume Command gives you the CLI command without launching it."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“Copy Resume Command”会复制 CLI 命令，但不会运行它。"
           }
         }
       }
@@ -412,6 +646,12 @@
             "state": "translated",
             "value": "Copy Session ID on a side chat copies its parent thread ID."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在支线对话中使用“Copy Session ID”会复制其父对话的 ID。"
+          }
         }
       }
     },
@@ -421,6 +661,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Copy exact commands"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制完整命令"
           }
         }
       }
@@ -432,6 +678,12 @@
             "state": "translated",
             "value": "Copy the transcript"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制对话记录"
+          }
         }
       }
     },
@@ -441,6 +693,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Disable unused providers from Settings so they stay out of filters."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在“设置”中停用不使用的提供商，使其不再出现在筛选器中。"
           }
         }
       }
@@ -453,6 +711,12 @@
             "state": "translated",
             "value": "Done"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
+          }
         }
       }
     },
@@ -462,6 +726,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Double-click project names in the session list."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在会话列表中连按项目名称。"
           }
         }
       }
@@ -473,6 +743,12 @@
             "state": "translated",
             "value": "Enable live session detection (Beta) in Settings → Quota Meter."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在“设置”→“额度监视器”中启用实时会话检测（Beta）。"
+          }
         }
       }
     },
@@ -482,6 +758,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enable usage strips"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用用量条"
           }
         }
       }
@@ -493,6 +775,12 @@
             "state": "translated",
             "value": "Expand All"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部展开"
+          }
         }
       }
     },
@@ -502,6 +790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Export as Markdown"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出为 Markdown"
           }
         }
       }
@@ -513,6 +807,12 @@
             "state": "translated",
             "value": "Filter by project"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按项目筛选"
+          }
         }
       }
     },
@@ -522,6 +822,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Filter to favorites"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅显示个人收藏"
           }
         }
       }
@@ -533,6 +839,12 @@
             "state": "translated",
             "value": "Filter to side chats"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅显示支线对话"
+          }
         }
       }
     },
@@ -542,6 +854,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Filters keep the session list focused."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "筛选器可让会话列表更聚焦。"
           }
         }
       }
@@ -553,6 +871,12 @@
             "state": "translated",
             "value": "Find in Transcript…"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在对话记录中查找…"
+          }
         }
       }
     },
@@ -563,6 +887,12 @@
             "state": "translated",
             "value": "Find the parent thread"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查找父对话串"
+          }
         }
       }
     },
@@ -572,6 +902,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Focus a live agent"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聚焦正在运行的智能体"
           }
         }
       }
@@ -584,6 +920,12 @@
             "state": "translated",
             "value": "Hide Dock Icon"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏程序坞图标"
+          }
         }
       }
     },
@@ -593,6 +935,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hide noisy sessions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏干扰会话"
           }
         }
       }
@@ -604,6 +952,12 @@
             "state": "translated",
             "value": "Hide the Dock icon"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏程序坞图标"
+          }
         }
       }
     },
@@ -614,6 +968,12 @@
             "state": "translated",
             "value": "Image Browser"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图像浏览器"
+          }
         }
       }
     },
@@ -623,6 +983,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Image-heavy sessions have dedicated navigation."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包含大量图像的会话可使用专用导航。"
           }
         }
       }
@@ -635,6 +1001,12 @@
             "state": "translated",
             "value": "Images"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图像"
+          }
         }
       }
     },
@@ -644,6 +1016,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Jump image prompts"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳转到含图提示"
           }
         }
       }
@@ -655,6 +1033,12 @@
             "state": "translated",
             "value": "Jump to the repo folder for the active agent session."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳转到当前智能体会话的仓库文件夹。"
+          }
         }
       }
     },
@@ -664,6 +1048,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keep Agent Cockpit in a screen corner so active and waiting sessions stay visible."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将智能体监控台放在屏幕一角，让运行中和等待中的会话始终可见。"
           }
         }
       }
@@ -675,6 +1065,12 @@
             "state": "translated",
             "value": "Keep important sessions easy to find."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让重要会话更容易找到。"
+          }
         }
       }
     },
@@ -685,6 +1081,12 @@
             "state": "translated",
             "value": "Keep live agent work visible without switching terminal tabs."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无需切换终端标签页，也能随时查看智能体的实时工作。"
+          }
         }
       }
     },
@@ -694,6 +1096,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Keep usage state visible without opening the main window."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无需打开主窗口，也能随时查看用量状态。"
           }
         }
       }
@@ -706,6 +1114,12 @@
             "state": "translated",
             "value": "Later"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后"
+          }
         }
       }
     },
@@ -715,6 +1129,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Live Session Context"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实时会话上下文"
           }
         }
       }
@@ -726,6 +1146,12 @@
             "state": "translated",
             "value": "Long transcripts are easier with keyboard controls."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用键盘操作可更轻松地阅读长对话记录。"
+          }
         }
       }
     },
@@ -735,6 +1161,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Move through matches"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在匹配项之间跳转"
           }
         }
       }
@@ -747,6 +1179,12 @@
             "state": "translated",
             "value": "Next"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下一步"
+          }
         }
       }
     },
@@ -758,6 +1196,12 @@
             "state": "translated",
             "value": "OK"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
         }
       }
     },
@@ -767,6 +1211,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Old Desktop sessions stay reachable."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "旧的 Desktop 会话仍可访问。"
           }
         }
       }
@@ -778,6 +1228,12 @@
             "state": "translated",
             "value": "Only enable the providers you use."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅启用你使用的提供商。"
+          }
         }
       }
     },
@@ -787,6 +1243,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Open Image Browser"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开图像浏览器"
           }
         }
       }
@@ -798,6 +1260,12 @@
             "state": "translated",
             "value": "Open View > Agent Cockpit to monitor active iTerm2 sessions from Codex CLI, Claude Code, and OpenCode."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开“显示”>“智能体监控台”，监控 Codex CLI、Claude Code 和 OpenCode 在 iTerm2 中的活跃会话。"
+          }
         }
       }
     },
@@ -807,6 +1275,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Open the session log in Finder from a live Cockpit row."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从监控台的实时会话行中，在 Finder 打开会话日志。"
           }
         }
       }
@@ -818,6 +1292,12 @@
             "state": "translated",
             "value": "Open the working directory"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开工作目录"
+          }
         }
       }
     },
@@ -827,6 +1307,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pin Cockpit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定监控台"
           }
         }
       }
@@ -839,6 +1325,12 @@
             "state": "translated",
             "value": "Power Tips"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实用技巧"
+          }
         }
       }
     },
@@ -848,6 +1340,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Quick Navigation"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速导航"
           }
         }
       }
@@ -859,6 +1357,12 @@
             "state": "translated",
             "value": "Quota Meter"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "额度监视器"
+          }
         }
       }
     },
@@ -869,6 +1373,12 @@
             "state": "translated",
             "value": "Reading Controls"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "阅读控制"
+          }
         }
       }
     },
@@ -878,6 +1388,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reduce Noise"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "减少干扰"
           }
         }
       }
@@ -890,6 +1406,12 @@
             "state": "translated",
             "value": "Refresh"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
         }
       }
     },
@@ -899,6 +1421,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reopen from Help → Power Tips"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从“帮助”→“实用技巧”重新打开"
           }
         }
       }
@@ -910,6 +1438,12 @@
             "state": "translated",
             "value": "Reopen them later from Saved Sessions."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后可从“已保存的会话”中重新打开它们。"
+          }
         }
       }
     },
@@ -919,6 +1453,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restore Claude archives"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复 Claude 归档"
           }
         }
       }
@@ -930,6 +1470,12 @@
             "state": "translated",
             "value": "Resume Work"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续工作"
+          }
         }
       }
     },
@@ -939,6 +1485,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resume past work"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续以往工作"
           }
         }
       }
@@ -950,6 +1502,12 @@
             "state": "translated",
             "value": "Resume the parent"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续父会话"
+          }
         }
       }
     },
@@ -959,6 +1517,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resuming a workflow child resolves to its parent session."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续工作流子会话时，会转到其父会话。"
           }
         }
       }
@@ -970,6 +1534,12 @@
             "state": "translated",
             "value": "Return to past agent sessions from the session list."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从会话列表继续以前的智能体会话。"
+          }
         }
       }
     },
@@ -979,6 +1549,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reveal the log"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示日志"
           }
         }
       }
@@ -990,6 +1566,12 @@
             "state": "translated",
             "value": "Review images embedded in sessions."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看会话中嵌入的图像。"
+          }
         }
       }
     },
@@ -999,6 +1581,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Right-click supported sessions to continue where you left off."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右键点按支持的会话，即可从上次中断的位置继续。"
           }
         }
       }
@@ -1010,6 +1598,12 @@
             "state": "translated",
             "value": "Save a session transcript when you need to keep or share it."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要保留或共享会话时，可保存其对话记录。"
+          }
         }
       }
     },
@@ -1020,6 +1614,12 @@
             "state": "translated",
             "value": "Saved Only"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅显示已保存的会话"
+          }
         }
       }
     },
@@ -1029,6 +1629,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Saved Sessions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存的会话"
           }
         }
       }
@@ -1041,6 +1647,12 @@
             "state": "translated",
             "value": "Search"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索"
+          }
         }
       }
     },
@@ -1050,6 +1662,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search Codex archives"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索 Codex 归档"
           }
         }
       }
@@ -1061,6 +1679,12 @@
             "state": "translated",
             "value": "Search Faster"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更快搜索"
+          }
         }
       }
     },
@@ -1070,6 +1694,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search Sessions…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索会话…"
           }
         }
       }
@@ -1081,6 +1711,12 @@
             "state": "translated",
             "value": "Search across sessions"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跨会话搜索"
+          }
         }
       }
     },
@@ -1090,6 +1726,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search inside one session"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在单个会话中搜索"
           }
         }
       }
@@ -1101,6 +1743,12 @@
             "state": "translated",
             "value": "Settings can hide zero-message, low-message, housekeeping, or probe sessions."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可在“设置”中隐藏无消息、消息很少、维护或探测类会话。"
+          }
         }
       }
     },
@@ -1110,6 +1758,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Settings…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
           }
         }
       }
@@ -1121,6 +1775,12 @@
             "state": "translated",
             "value": "Show Onboarding"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示新手引导"
+          }
         }
       }
     },
@@ -1130,6 +1790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Show command sessions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示命令会话"
           }
         }
       }
@@ -1141,6 +1807,12 @@
             "state": "translated",
             "value": "Show or hide the Quota Meter."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示或隐藏额度监视器。"
+          }
         }
       }
     },
@@ -1150,6 +1822,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Side Chats"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支线对话"
           }
         }
       }
@@ -1161,6 +1839,12 @@
             "state": "translated",
             "value": "Small shortcuts help when scanning lots of history."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一些快捷操作可帮助你快速浏览大量历史记录。"
+          }
         }
       }
     },
@@ -1171,6 +1855,12 @@
             "state": "translated",
             "value": "Spot fan-out"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "识别并行分支"
+          }
         }
       }
     },
@@ -1180,6 +1870,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Star important sessions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "收藏重要会话"
           }
         }
       }
@@ -1192,6 +1888,12 @@
             "state": "translated",
             "value": "Step %1$lld of %2$lld"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %1$lld 步，共 %2$lld 步"
+          }
         }
       }
     },
@@ -1202,6 +1904,12 @@
             "state": "translated",
             "value": "Switch between Session, Text, and JSON views for readability or raw structure."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在“会话”、“文本”和 JSON 视图之间切换，以便阅读或查看原始结构。"
+          }
         }
       }
     },
@@ -1211,6 +1919,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Switch views depending on what you need."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根据需要切换视图。"
           }
         }
       }
@@ -1223,6 +1937,12 @@
             "state": "translated",
             "value": "The 5h limit window has reset."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5h 额度周期已重置。"
+          }
         }
       }
     },
@@ -1232,6 +1952,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toggle Dark/Light"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换深色/浅色模式"
           }
         }
       }
@@ -1243,6 +1969,12 @@
             "state": "translated",
             "value": "Track Codex and Claude rate-limit state in the app."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 App 中跟踪 Codex 和 Claude 的速率限制状态。"
+          }
         }
       }
     },
@@ -1252,6 +1984,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transcript Tools"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对话记录工具"
           }
         }
       }
@@ -1263,6 +2001,12 @@
             "state": "translated",
             "value": "Transcript Window"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对话记录窗口"
+          }
         }
       }
     },
@@ -1272,6 +2016,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Turn it on from Settings > Advanced. Agent Sessions keeps the menu bar item enabled so the app remains reachable."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可在“设置”>“高级”中启用。Agent Sessions 会保留菜单栏项目，以便你仍能打开 App。"
           }
         }
       }
@@ -1283,6 +2033,12 @@
             "state": "translated",
             "value": "Usage Limits"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用量限制"
+          }
         }
       }
     },
@@ -1292,6 +2048,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Usage surfaces can stay visible while agents run."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能体运行时，用量信息可以始终保持可见。"
           }
         }
       }
@@ -1304,6 +2066,12 @@
             "state": "translated",
             "value": "Use #side, or #side phrase to search within them."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 #side 或 #side 加关键词即可在其中搜索。"
+          }
         }
       }
     },
@@ -1313,6 +2081,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Use Agent Cockpit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用智能体监控台"
           }
         }
       }
@@ -1325,6 +2099,12 @@
             "state": "translated",
             "value": "Use Back and Next to move through the Power Tips tour."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用“返回”和“下一步”浏览“实用技巧”。"
+          }
         }
       }
     },
@@ -1335,6 +2115,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Use Command-F while reading a transcript."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "阅读对话记录时使用 Command-F。"
           }
         }
       }
@@ -1347,6 +2133,12 @@
             "state": "translated",
             "value": "Use Command-G and Shift-Command-G after searching a transcript."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索对话记录后，使用 Command-G 和 Shift-Command-G 在匹配项之间跳转。"
+          }
         }
       }
     },
@@ -1358,6 +2150,12 @@
             "state": "translated",
             "value": "Use Command-Plus and Command-Minus while reading."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "阅读时使用 Command-Plus 和 Command-Minus 调整文字大小。"
+          }
         }
       }
     },
@@ -1368,6 +2166,12 @@
             "state": "translated",
             "value": "Use Focus in iTerm2 from Cockpit when you need to jump back to a running agent."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要返回正在运行的智能体时，在监控台中使用 Focus in iTerm2。"
+          }
         }
       }
     },
@@ -1377,6 +2181,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Use System Appearance"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用系统外观"
           }
         }
       }
@@ -1389,6 +2199,12 @@
             "state": "translated",
             "value": "Use Unified Search with Option-Command-F."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 Option-Command-F 打开统一搜索。"
+          }
         }
       }
     },
@@ -1398,6 +2214,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Use favorites-only mode when you want a short working set."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要精简工作集时，可使用仅显示个人收藏模式。"
           }
         }
       }
@@ -1409,6 +2231,12 @@
             "state": "translated",
             "value": "Use menu bar meters"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用菜单栏用量计"
+          }
         }
       }
     },
@@ -1418,6 +2246,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Use the Images control in a transcript to move between image prompts."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用对话记录中的“图像”控件，在包含图像的提示之间跳转。"
           }
         }
       }
@@ -1430,6 +2264,12 @@
             "state": "translated",
             "value": "Use the archive icon on the Claude filter (Command-2), then restore in place from the transcript."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 Claude 筛选器上的归档图标（Command-2），然后在对话记录中原位恢复。"
+          }
         }
       }
     },
@@ -1439,6 +2279,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Use the commands-only filter to focus on sessions that ran tools or shell commands."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用仅显示命令筛选器，专注于运行过工具或 shell 命令的会话。"
           }
         }
       }
@@ -1450,6 +2296,12 @@
             "state": "translated",
             "value": "Use the transcript toolbar to copy the full session."
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用对话记录工具栏复制完整会话。"
+          }
         }
       }
     },
@@ -1459,6 +2311,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Use the two search surfaces for different jobs."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "针对不同任务使用两种搜索方式。"
           }
         }
       }
@@ -1471,6 +2329,12 @@
             "state": "translated",
             "value": "View"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示"
+          }
         }
       }
     },
@@ -1480,6 +2344,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "What's New"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新功能"
           }
         }
       }
@@ -1491,6 +2361,12 @@
             "state": "translated",
             "value": "Workflow Subagents"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作流子智能体"
+          }
         }
       }
     },
@@ -1500,6 +2376,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Workflow subagents nest under the session that launched them with a workflow badge."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作流子智能体会显示在启动它们的会话下方，并带有工作流标记。"
           }
         }
       }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+- Added complete Simplified Chinese localization for app copy, menus, onboarding, notifications, accessibility labels, and macOS permission prompts.
+
 ### Bug Fixes
 - **Quota Meter no longer reconnects forever when Claude account access is unavailable.** A persistent Claude billing response becomes an actionable `Claude plan inactive` row after 90 seconds, with a one-shot notification and a compact Hide action; a long server-directed rate limit now stays a calm `rate limited` row with its own Hide action instead of being erased by a failed fallback and returning to an endless spinner. Server retry timing also wins over stale cold-start work. A permission-only 403 still uses the normal fallback routes. A new agent selector in Quota Meter and Usage Tracking settings can independently hide Codex or Claude without stopping tracking, menu-bar data, the main-window footer, or session indexing.
 - **Antigravity and OpenCode keep their intended colors across macOS releases.** Their accents and toolbar pills no longer inherit Apple system palette changes, so the same Agent Sessions build renders consistently on macOS 15 and 26.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Features
-- Added complete Simplified Chinese localization for app copy, menus, onboarding, notifications, accessibility labels, and macOS permission prompts.
+- Added Simplified Chinese translations for every entry currently in the app and Info.plist String Catalogs, covering onboarding, menus, notifications, accessibility labels, and macOS permission prompts.
 
 ### Bug Fixes
 - **Quota Meter no longer reconnects forever when Claude account access is unavailable.** A persistent Claude billing response becomes an actionable `Claude plan inactive` row after 90 seconds, with a one-shot notification and a compact Hide action; a long server-directed rate limit now stays a calm `rate limited` row with its own Hide action instead of being erased by a failed fallback and returning to an endless spinner. Server retry timing also wins over stale cold-start work. A permission-only 403 still uses the normal fallback routes. A new agent selector in Quota Meter and Usage Tracking settings can independently hide Codex or Claude without stopping tracking, menu-bar data, the main-window footer, or session indexing.

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,9 +1,9 @@
 # Localization conventions
 
 Agent Sessions uses English as its source language. Simplified Chinese,
-identified as `zh-Hans`, is the planned first translation; it is not currently
-supported. A locale is not considered supported until both catalogs are
-complete and a human has reviewed them.
+identified as `zh-Hans`, is the first supported translation. Both catalogs are
+complete and human-reviewed. Some user-visible source strings are not yet in
+the catalogs; expanding that source coverage is separate follow-up work.
 
 ## Catalogs
 
@@ -12,7 +12,7 @@ complete and a human has reviewed them.
   `AgentSessions/Resources/InfoPlist.xcstrings`.
 - Both catalogs declare `en` as their source language. Do not add a locale to a
   catalog until its translation is ready for review.
-- CI permits the planned `zh-Hans` locale only when it is present, non-empty,
+- CI permits the `zh-Hans` locale only when it is present, non-empty,
   and marked translated for every key in both catalogs. Partial locale imports
   and unreviewed locale identifiers fail validation.
 - Keep catalog changes deterministic and reviewable. CI compiles catalogs into a
@@ -68,7 +68,7 @@ unchanged unless a future translation decision explicitly documents otherwise.
 
 ## Review and validation
 
-Before adding `zh-Hans`:
+Before adding or updating a locale:
 
 1. Build the app and run the focused localization tests.
 2. Run `scripts/validate_localization_catalogs.py` and confirm both catalogs

--- a/docs/summaries/2026-09.md
+++ b/docs/summaries/2026-09.md
@@ -1,6 +1,6 @@
 # September 2026
 
-- Added complete Simplified Chinese translations for the app and Info.plist String Catalogs, including onboarding, menus, notifications, accessibility copy, and macOS permission prompts.
+- Added Simplified Chinese translations for every entry currently in the app and Info.plist String Catalogs, including onboarding, menus, notifications, accessibility copy, and macOS permission prompts.
 - Established the localization foundation for the planned Simplified Chinese contribution: English app and Info.plist catalogs, stable identifiers independent of translated display text, typed localizable-versus-verbatim boundaries, pluralized session counts, locale-aware notification durations, and CI validation that rejects partial locale imports and catalog/source drift.
 - Quota Meter now turns persistent Claude billing/account-access failures into an actionable `Claude plan inactive` state after 90 seconds, with a one-shot notification and inline Hide action; long server-directed rate limits stay on a calm `rate limited` row with Hide even when a fallback fails, and stale cold-start work cannot replace the server retry schedule, while scope-only 403 responses remain eligible for usage fallbacks.
 - Codex and Claude can be shown or hidden independently from Quota Meter or Usage Tracking settings; hiding changes only Quota Meter presentation and leaves tracking, footer/menu-bar data, and session indexing intact.

--- a/docs/summaries/2026-09.md
+++ b/docs/summaries/2026-09.md
@@ -1,5 +1,6 @@
 # September 2026
 
+- Added complete Simplified Chinese translations for the app and Info.plist String Catalogs, including onboarding, menus, notifications, accessibility copy, and macOS permission prompts.
 - Established the localization foundation for the planned Simplified Chinese contribution: English app and Info.plist catalogs, stable identifiers independent of translated display text, typed localizable-versus-verbatim boundaries, pluralized session counts, locale-aware notification durations, and CI validation that rejects partial locale imports and catalog/source drift.
 - Quota Meter now turns persistent Claude billing/account-access failures into an actionable `Claude plan inactive` state after 90 seconds, with a one-shot notification and inline Hide action; long server-directed rate limits stay on a calm `rate limited` row with Hide even when a fallback fails, and stale cold-start work cannot replace the server retry schedule, while scope-only 403 responses remain eligible for usage fallbacks.
 - Codex and Claude can be shown or hidden independently from Quota Meter or Usage Tracking settings; hiding changes only Quota Meter presentation and leaves tracking, footer/menu-bar data, and session indexing intact.

--- a/scripts/tests/test_validate_localization_catalogs.py
+++ b/scripts/tests/test_validate_localization_catalogs.py
@@ -129,7 +129,7 @@ class LocalizationCatalogValidatorTests(unittest.TestCase):
             validator.INFO_PLIST,
             skip_xcstringstool=False,
         )
-        self.assertEqual(counts, (145, 6, set()))
+        self.assertEqual(counts, (145, 6, {"zh-Hans"}))
 
     def test_complete_zh_hans_in_both_catalogs_passes(self) -> None:
         app_strings = {"Hello": string_entry("Hello")}


### PR DESCRIPTION
## Summary

- add complete `zh-Hans` translations for all 145 entries in `Localizable.xcstrings`
- add complete `zh-Hans` translations for all 6 entries in `InfoPlist.xcstrings`
- preserve product/provider names, CLI names, search operators, commands, keyboard shortcuts, placeholders, and plural variants
- update the current-catalog validator test to expect the newly completed `zh-Hans` locale
- document the user-visible localization under Unreleased

No Swift source or Xcode project files are changed.

## Validation

- `python3 -m unittest scripts.tests.test_validate_localization_catalogs` — 17 passed
- `python3 scripts/validate_localization_catalogs.py` — 145 app keys, 6 Info.plist keys, `zh-Hans` complete
- `./scripts/xcode_test_stable.sh -testLanguage en -testRegion US CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=` — 2,586 tests, 2,583 passed, 3 skipped, 0 failed
- ad-hoc-signed Debug build — succeeded
- `codesign --verify --deep --strict` — passed

The explicit English test language keeps the existing English-baseline assertions deterministic on a Simplified Chinese macOS installation. The signing overrides are local-only because the fork does not have the upstream development certificate.

## Review notes

I personally reviewed the Chinese wording and also ran a separate read-only review. The catalogs contain translated values for every requested entry, with no blocking linguistic findings.

While testing the built app, I found that some user-visible strings are still outside these 145 catalog entries, so the current result can be mixed-language. I am asking in issue #68 whether you would like me to expand the localization work in a follow-up after this catalog-focused PR.